### PR TITLE
Feature: Env files

### DIFF
--- a/packages/millicast-publisher-demo/.env.sample
+++ b/packages/millicast-publisher-demo/.env.sample
@@ -1,4 +1,4 @@
 # Make a .env file with the following vars
-STREAM_ID=test
-ACCOUNT_ID=test
-PUBLISH_TOKEN=test
+MILLICAST_STREAM_ID=test
+MILLICAST_ACCOUNT_ID=test
+MILLICAST_PUBLISH_TOKEN=test

--- a/packages/millicast-publisher-demo/env.js
+++ b/packages/millicast-publisher-demo/env.js
@@ -1,0 +1,19 @@
+import dotenv from 'dotenv'
+
+const MILLICAST = /^MILLICAST_/i
+
+const getEnvironment = () => {
+  dotenv.config()
+
+  return Object.keys(process.env)
+    .filter(key => MILLICAST.test(key))
+    .reduce(
+      (env, key) => {
+        env[key] = process.env[key]
+        return env
+      },
+      {}
+    )
+}
+
+export default getEnvironment

--- a/packages/millicast-publisher-demo/rollup.config.js
+++ b/packages/millicast-publisher-demo/rollup.config.js
@@ -1,11 +1,12 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import injectProcessEnv from 'rollup-plugin-inject-process-env'
-import dotenv from 'dotenv'
 import { terser } from 'rollup-plugin-terser'
 import { babel } from '@rollup/plugin-babel'
 
-const environment = dotenv.config()
+import getEnvironment from './env'
+
+const environment = getEnvironment()
 
 export default [
   {
@@ -25,7 +26,7 @@ export default [
         transformMixedEsModules: true
       }),
       injectProcessEnv({
-        ...environment.parsed
+        ...environment
       }),
       babel({
         babelHelpers: 'runtime',

--- a/packages/millicast-publisher-demo/src/publisher.js
+++ b/packages/millicast-publisher-demo/src/publisher.js
@@ -1,8 +1,8 @@
 import MillicastPublishUserMedia from './js/MillicastPublishUserMedia'
 
-const streamId = process.env.STREAM_ID
-const accountId = process.env.ACCOUNT_ID
-const publishToken = process.env.PUBLISH_TOKEN
+const streamId = process.env.MILLICAST_STREAM_ID
+const accountId = process.env.MILLICAST_ACCOUNT_ID
+const publishToken = process.env.MILLICAST_PUBLISH_TOKEN
 const disableVideo = false
 const disableAudio = false
 const disableStereo = false

--- a/packages/millicast-viewer-demo/.env.sample
+++ b/packages/millicast-viewer-demo/.env.sample
@@ -1,4 +1,3 @@
 # Make a .env file with the following vars
-STREAM_ID=test
-ACCOUNT_ID=test
-PUBLISH_TOKEN=test
+MILLICAST_STREAM_ID=test
+MILLICAST_ACCOUNT_ID=test

--- a/packages/millicast-viewer-demo/env.js
+++ b/packages/millicast-viewer-demo/env.js
@@ -1,0 +1,19 @@
+import dotenv from 'dotenv'
+
+const MILLICAST = /^MILLICAST_/i
+
+const getEnvironment = () => {
+  dotenv.config()
+
+  return Object.keys(process.env)
+    .filter(key => MILLICAST.test(key))
+    .reduce(
+      (env, key) => {
+        env[key] = process.env[key]
+        return env
+      },
+      {}
+    )
+}
+
+export default getEnvironment

--- a/packages/millicast-viewer-demo/rollup.config.js
+++ b/packages/millicast-viewer-demo/rollup.config.js
@@ -1,11 +1,12 @@
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import injectProcessEnv from 'rollup-plugin-inject-process-env'
-import dotenv from 'dotenv'
 import { terser } from 'rollup-plugin-terser'
 import { babel } from '@rollup/plugin-babel'
 
-const environment = dotenv.config()
+import getEnvironment from './env'
+
+const environment = getEnvironment()
 
 export default [
   {
@@ -25,7 +26,7 @@ export default [
         transformMixedEsModules: true
       }),
       injectProcessEnv({
-        ...environment.parsed
+        ...environment
       }),
       babel({
         babelHelpers: 'runtime',

--- a/packages/millicast-viewer-demo/src/viewer.js
+++ b/packages/millicast-viewer-demo/src/viewer.js
@@ -10,10 +10,10 @@ const url = !!href.searchParams.get("url")
   : "wss://turn.millicast.com/millisock";
 const streamId = !!href.searchParams.get("streamId")
   ? href.searchParams.get("streamId")
-  : process.env.STREAM_ID;
+  : process.env.MILLICAST_STREAM_ID;
 const streamAccountId = !!href.searchParams.get("streamAccountId")
   ? href.searchParams.get("streamAccountId")
-  : process.env.ACCOUNT_ID;
+  : process.env.MILLICAST_ACCOUNT_ID;
 
 const disableVideo = href.searchParams.get("disableVideo") === "true";
 const disableAudio = href.searchParams.get("disableAudio") === "true";


### PR DESCRIPTION
Add MILLICAST_ prefix to all env variables.
Now we can set these variables via .env file or in our environment. If you set a variable in .env file that is already setted in user environment, it'll be skipped.