### PR TITLE
Feature: Secure subscribers

### DIFF
--- a/packages/millicast-sdk-js/src/MillicastDirector.js
+++ b/packages/millicast-sdk-js/src/MillicastDirector.js
@@ -4,14 +4,15 @@ import MillicastLogger from './MillicastLogger'
 const logger = MillicastLogger.get('MillicastDirector')
 const publisherLocation = 'https://director.millicast.com/api/director/publish'
 const subscriberLocation = 'https://director.millicast.com/api/director/subscribe'
+const streamTypes = {
+  WEBRTC: 'WebRtc',
+  RTMP: 'Rtmp'
+}
 
 /**
  * @typedef {Object} MillicastDirectorResponse
  * @property {Array<String>} urls - WebSocket available URLs.
- * @property {String} wsUrl - Deprecated: You should use the first url in `urls`.
  * @property {String} jwt - Access token for signaling initialization.
- * @property {String} streamAccountId - Millicast publisher Account ID.
- * @property {Boolean} [subscribeRequiresAuth] - True if subscriber requires authentication, otherwise false.
  */
 
 /**
@@ -28,6 +29,7 @@ export default class MillicastDirector {
    * Get publisher connection data.
    * @param {String} token - Millicast Publishing Token.
    * @param {String} streamName - Millicast Stream Name.
+   * @param {("WebRtc" | "Rtmp")} [streamType] - Millicast Stream Type.
    * @returns {Promise<MillicastDirectorResponse>} Promise object which represents the result of getting the publishing connection path.
    * @example const response = await MillicastDirector.getPublisher(token, streamName)
    * @example
@@ -55,9 +57,9 @@ export default class MillicastDirector {
    * await millicastPublish.broadcast(broadcastOptions)
    */
 
-  static async getPublisher (token, streamName) {
+  static async getPublisher (token, streamName, streamType = streamTypes.WEBRTC) {
     logger.info('Getting publisher connection path for stream name: ', streamName)
-    const payload = { streamName }
+    const payload = { streamName, streamType }
     const headers = { Authorization: `Bearer ${token}` }
     try {
       const { data } = await axios.post(publisherLocation, payload, { headers })
@@ -74,6 +76,7 @@ export default class MillicastDirector {
    * @param {String} streamAccountId - Millicast Account ID.
    * @param {String} streamName - Millicast publisher Stream Name.
    * @param {String} [subscriberToken] - Token to subscribe to secure streams. If you are subscribing to an unsecure stream, you can omit this param.
+   * @param {("WebRtc" | "Rtmp")} [streamType] - Millicast Stream Type.
    * @returns {Promise<MillicastDirectorResponse>} Promise object which represents the result of getting the subscribe connection data.
    * @example const response = await MillicastDirector.getSubscriber(streamAccountId, streamName)
    * @example
@@ -107,12 +110,11 @@ export default class MillicastDirector {
    * await millicastView.connect(options)
    */
 
-  static async getSubscriber (streamAccountId, streamName, subscriberToken = null) {
+  static async getSubscriber (streamAccountId, streamName, subscriberToken = null, streamType = streamTypes.WEBRTC) {
     logger.info(`Getting subscriber connection data for stream name: ${streamName} and account id: ${streamAccountId}`)
-    const payload = { streamAccountId, streamName }
+    const payload = { streamAccountId, streamName, streamType }
     let headers = {}
     if (subscriberToken) {
-      delete payload.unauthorizedSubscribe
       headers = { Authorization: `Bearer ${subscriberToken}` }
     }
     try {


### PR DESCRIPTION
Refers to task:
https://app.asana.com/0/1199970550606439/1200136710555209

We're waiting for an anwser of the following question to approve this PR.
_

> The `unauthorizedSubscribe` property in payload for https://director.millicast.com/api/director/subscribe is still in use?
> Because in Securing your Millicast Viewer example, it wasn't set in payload, and for unsecure mode it return OK when we omit this property.
> Do we have to continue setting this property in director's calls?

_

**UPDATE**
We receive the following answer, so now we are able to review and merge this PR

> just for your further info as well, you can also see the request/response DTOs in the openapi/swagger for Director here
https://apidocs.millicast.com/redoc/?url=https://director-dev.millicast.com/openapi/v1/openapi.json
(only pointing at dev environment because there is a CORS bug yet to be pushed to production to allow viewing docs), is identical to production currently