### PR TITLE
Fix: Audio track not working with H.264

### DIFF
--- a/packages/millicast-sdk/src/PeerConnection.js
+++ b/packages/millicast-sdk/src/PeerConnection.js
@@ -181,7 +181,7 @@ export default class PeerConnection extends EventEmitter {
     logger.debug('Peer offer response: ', response.sdp)
 
     this.sessionDescription = response
-    this.sessionDescription.sdp = SdpParser.setMultiopus(this.sessionDescription.sdp)
+    this.sessionDescription.sdp = SdpParser.setMultiopus(this.sessionDescription.sdp, options.codec)
     if (options.simulcast) {
       this.sessionDescription.sdp = SdpParser.setSimulcast(this.sessionDescription.sdp, options.codec)
     }

--- a/packages/millicast-sdk/src/PeerConnection.js
+++ b/packages/millicast-sdk/src/PeerConnection.js
@@ -181,7 +181,7 @@ export default class PeerConnection extends EventEmitter {
     logger.debug('Peer offer response: ', response.sdp)
 
     this.sessionDescription = response
-    this.sessionDescription.sdp = SdpParser.setMultiopus(this.sessionDescription.sdp, options.codec)
+    this.sessionDescription.sdp = SdpParser.setMultiopus(this.sessionDescription.sdp)
     if (options.simulcast) {
       this.sessionDescription.sdp = SdpParser.setSimulcast(this.sessionDescription.sdp, options.codec)
     }

--- a/packages/millicast-sdk/src/utils/SdpParser.js
+++ b/packages/millicast-sdk/src/utils/SdpParser.js
@@ -163,12 +163,13 @@ export default class SdpParser {
    *
    * **Only available in Google Chrome.**
    * @param {String} sdp - Current SDP.
+   * @param {String} codec - Current codec selected.
    * @returns {String} SDP parsed with multiopus support.
    * @example SdpParser.setMultiopus(sdp)
    */
-  static setMultiopus (sdp) {
+  static setMultiopus (sdp, codec) {
     const browserData = new UserAgent()
-    if (browserData.isChrome()) {
+    if (browserData.isChrome() && codec !== 'h264') {
       if (!sdp.includes('multiopus/48000/6')) {
         logger.info('Setting multiopus')
         // Find the audio m-line

--- a/packages/millicast-sdk/src/utils/SdpParser.js
+++ b/packages/millicast-sdk/src/utils/SdpParser.js
@@ -4,6 +4,15 @@ import UserAgent from './UserAgent'
 
 const logger = Logger.get('SdpParser')
 
+const firstPayloadTypeLowerRange = 35
+const lastPayloadTypeLowerRange = 65
+
+const firstPayloadTypeUpperRange = 96
+const lastPayloadTypeUpperRange = 127
+
+const payloadTypeLowerRange = Array.from({ length: (lastPayloadTypeLowerRange - firstPayloadTypeLowerRange) + 1 }, (_, i) => i + firstPayloadTypeLowerRange)
+const payloadTypeUppperRange = Array.from({ length: (lastPayloadTypeUpperRange - firstPayloadTypeUpperRange) + 1 }, (_, i) => i + firstPayloadTypeUpperRange)
+
 /**
  * Simplify SDP parser.
  *
@@ -163,13 +172,12 @@ export default class SdpParser {
    *
    * **Only available in Google Chrome.**
    * @param {String} sdp - Current SDP.
-   * @param {String} codec - Current codec selected.
    * @returns {String} SDP parsed with multiopus support.
    * @example SdpParser.setMultiopus(sdp)
    */
-  static setMultiopus (sdp, codec) {
+  static setMultiopus (sdp) {
     const browserData = new UserAgent()
-    if (browserData.isChrome() && codec !== 'h264') {
+    if (browserData.isChrome()) {
       if (!sdp.includes('multiopus/48000/6')) {
         logger.info('Setting multiopus')
         // Find the audio m-line
@@ -177,7 +185,7 @@ export default class SdpParser {
         // Get audio line
         const audio = res[0]
         // Get free payload number for multiopus
-        const pt = Math.max(...res[1].split(' ').map(Number)) + 1
+        const pt = SdpParser.getAvailablePayloadTypeRange(sdp)[0]
         // Add multiopus
         const multiopus = audio.replace('\r\n', ' ') + pt + '\r\n' +
               'a=rtpmap:' + pt + ' multiopus/48000/6\r\n' +
@@ -191,5 +199,25 @@ export default class SdpParser {
       }
     }
     return sdp
+  }
+
+  /**
+   * Gets all available payload type IDs of the current Session Description.
+   *
+   * @param {String} sdp - Current SDP.
+   * @returns {Array<Number>} All available payload type ids.
+   */
+  static getAvailablePayloadTypeRange (sdp) {
+    const regex = /m=(?:.*) (?:.*) UDP\/TLS\/RTP\/SAVPF (.*)\r\n/gm
+
+    const matches = sdp.matchAll(regex)
+    let ptAvailable = payloadTypeUppperRange.concat(payloadTypeLowerRange)
+
+    for (const match of matches) {
+      const usedNumbers = match[1].split(' ').map(n => parseInt(n))
+      ptAvailable = ptAvailable.filter(n => !usedNumbers.includes(n))
+    }
+
+    return ptAvailable
   }
 }

--- a/packages/millicast-viewer-demo/src/viewer.js
+++ b/packages/millicast-viewer-demo/src/viewer.js
@@ -54,7 +54,7 @@ let millicastView = null
 
 const newViewer = () => {
   const tokenGenerator = () => Director.getSubscriber(streamId, streamAccountId)
-  const millicastView = new View(streamId, tokenGenerator, autoReconnect)
+  const millicastView = new View(streamId, tokenGenerator, null, autoReconnect)
   millicastView.on("broadcastEvent", (event) => {
     if (!autoReconnect) return;
   


### PR DESCRIPTION
Due to #59 issue, enabling multiopus support with H.264 video codec causes that audio stream does not work and receives 0 bytes. 
This behaviour occurs with a 5.1 stream and with most common streams with max 2 channels. We are currently investigating why this happens, but now we decided to disable the multi-channel feature only with H.264.

## Update
The problem was that we are using the same payload type id of H.264 with multiopus. This was resolved calculating all available payload type ids and choosing one of them.