### PR TITLE
Fix: Renamed Stream Id variables to Stream Name

### DIFF
--- a/developer-info.md
+++ b/developer-info.md
@@ -21,7 +21,7 @@ $ npm run prepare
 Next, to build all packages add a `.env` file in both demo packages (`millicast-publisher-demo`, `millicast-viewer-demo` & `millicast-chromecast-receiver`). You can find the following example in `.env.sample`:
 ```sh
 # Make a .env file with the following vars
-MILLICAST_STREAM_ID=test
+MILLICAST_STREAM_NAME=test
 MILLICAST_ACCOUNT_ID=test
 MILLICAST_PUBLISH_TOKEN=test
 ```

--- a/packages/millicast-chromecast-receiver/.env.sample
+++ b/packages/millicast-chromecast-receiver/.env.sample
@@ -1,3 +1,3 @@
 # Make a .env file with the following vars
-MILLICAST_STREAM_ID=test
+MILLICAST_STREAM_NAME=test
 MILLICAST_ACCOUNT_ID=test

--- a/packages/millicast-chromecast-receiver/src/viewer.js
+++ b/packages/millicast-chromecast-receiver/src/viewer.js
@@ -14,15 +14,15 @@ const removeStream = () => {
   video.srcObject = null
 }
 
-const subscribe = async (streamId, streamAccountId) => {
-  const tokenGenerator = () => Director.getSubscriber(streamId, streamAccountId)
-  const millicastView = new View(streamId, tokenGenerator)
+const subscribe = async (streamName, streamAccountId) => {
+  const tokenGenerator = () => Director.getSubscriber(streamName, streamAccountId)
+  const millicastView = new View(streamName, tokenGenerator)
   millicastView.on('broadcastEvent', (event) => {
     const layers = event.data.layers !== null ? event.data.layers : {}
     if (event.name === 'layers' && Object.keys(layers).length <= 0) {
       // call play logic or being reconnect interval
       close().then(() => {
-        subscribe(streamId, streamAccountId)
+        subscribe(streamName, streamAccountId)
       })
       console.error('Feed no longer found.')
     }
@@ -42,7 +42,7 @@ const subscribe = async (streamId, streamAccountId) => {
     await millicastView.connect()
   } catch (error) {
     close().then(() => {
-      subscribe(streamId, streamAccountId)
+      subscribe(streamName, streamAccountId)
     })
     console.error(error)
   }
@@ -59,9 +59,9 @@ player.setMediaElement(document.querySelector('#player'))
 player.setMessageInterceptor(
   cast.framework.messages.MessageType.LOAD, loadRequestData => {
     const media = loadRequestData.media
-    const { streamId, streamAccountId } = media.customData
+    const { streamName, streamAccountId } = media.customData
 
-    subscribe(streamId, streamAccountId)
+    subscribe(streamName, streamAccountId)
 
     loadRequestData.media.contentUrl = 'https://www.sample-videos.com/video123/mp4/720/big_buck_bunny_720p_1mb.mp4'
     loadRequestData.media.contentType = 'video/mp4'

--- a/packages/millicast-publisher-demo/.env.sample
+++ b/packages/millicast-publisher-demo/.env.sample
@@ -1,4 +1,4 @@
 # Make a .env file with the following vars
-MILLICAST_STREAM_ID=test
+MILLICAST_STREAM_NAME=test
 MILLICAST_ACCOUNT_ID=test
 MILLICAST_PUBLISH_TOKEN=test

--- a/packages/millicast-publisher-demo/README.md
+++ b/packages/millicast-publisher-demo/README.md
@@ -4,7 +4,7 @@
 Add a `.env` file in current path. You can find the following example in `.env.sample`:
 ```sh
 # Make a .env file with the following vars
-MILLICAST_STREAM_ID=test
+MILLICAST_STREAM_NAME=test
 MILLICAST_ACCOUNT_ID=test
 MILLICAST_PUBLISH_TOKEN=test
 ```

--- a/packages/millicast-publisher-demo/src/publisher.js
+++ b/packages/millicast-publisher-demo/src/publisher.js
@@ -3,7 +3,7 @@ import { Director, Logger, StreamEvents } from "@millicast/sdk"
 
 window.Logger = Logger
 
-const streamId = process.env.MILLICAST_STREAM_ID
+const streamName = process.env.MILLICAST_STREAM_NAME
 const accountId = process.env.MILLICAST_ACCOUNT_ID
 const publishToken = process.env.MILLICAST_PUBLISH_TOKEN
 const disableVideo = false
@@ -73,7 +73,7 @@ document.addEventListener("DOMContentLoaded", async (event) => {
 
   // Add UserCount event listener
   const events = await StreamEvents.init()
-  events.onUserCount(accountId, streamId, ({count}) => {
+  events.onUserCount(accountId, streamName, ({count}) => {
     userCount.innerHTML = count
   })
   
@@ -124,8 +124,8 @@ document.addEventListener("DOMContentLoaded", async (event) => {
 
 
   /////////////////////////
-  const tokenGenerator = () => Director.getPublisher(publishToken, streamId)
-  const millicastPublishUserMedia = await MillicastPublishUserMedia.build({ streamName: streamId }, tokenGenerator, true)
+  const tokenGenerator = () => Director.getPublisher(publishToken, streamName)
+  const millicastPublishUserMedia = await MillicastPublishUserMedia.build({ streamName }, tokenGenerator, true)
   let selectedBandwidthBtn = document.querySelector('#bandwidthMenuButton');
   let bandwidth = 0
 
@@ -354,7 +354,7 @@ document.addEventListener("DOMContentLoaded", async (event) => {
       href = href.substring(0, href.lastIndexOf('/') + 1);
     }
 
-    let viewerUrl = `https://viewer.millicast.com/v2?streamId=${accountId}/${streamId}`;
+    let viewerUrl = `https://viewer.millicast.com/v2?streamId=${accountId}/${streamName}`;
 
     if (disableVideo === true) {
       viewerUrl = `${viewerUrl}&disableVideo=${disableVideo}`

--- a/packages/millicast-viewer-demo/.env.sample
+++ b/packages/millicast-viewer-demo/.env.sample
@@ -1,3 +1,3 @@
 # Make a .env file with the following vars
-MILLICAST_STREAM_ID=test
+MILLICAST_STREAM_NAME=test
 MILLICAST_ACCOUNT_ID=test

--- a/packages/millicast-viewer-demo/README.md
+++ b/packages/millicast-viewer-demo/README.md
@@ -4,7 +4,7 @@
 Add a `.env` file in current path. You can find the following example in `.env.sample`:
 ```sh
 # Make a .env file with the following vars
-MILLICAST_STREAM_ID=test
+MILLICAST_STREAM_NAME=test
 MILLICAST_ACCOUNT_ID=test
 MILLICAST_PUBLISH_TOKEN=test
 ```

--- a/packages/millicast-viewer-demo/src/viewer.js
+++ b/packages/millicast-viewer-demo/src/viewer.js
@@ -8,9 +8,9 @@ const href = new URL(window.location.href);
 const url = !!href.searchParams.get("url")
   ? href.searchParams.get("url")
   : "wss://turn.millicast.com/millisock";
-const streamId = !!href.searchParams.get("streamId")
-  ? href.searchParams.get("streamId")
-  : process.env.MILLICAST_STREAM_ID;
+const streamName = !!href.searchParams.get("streamName")
+  ? href.searchParams.get("streamName")
+  : process.env.MILLICAST_STREAM_NAME;
 const streamAccountId = !!href.searchParams.get("streamAccountId")
   ? href.searchParams.get("streamAccountId")
   : process.env.MILLICAST_ACCOUNT_ID;
@@ -53,8 +53,8 @@ let video = document.querySelector("video");
 let millicastView = null
 
 const newViewer = () => {
-  const tokenGenerator = () => Director.getSubscriber(streamId, streamAccountId)
-  const millicastView = new View(streamId, tokenGenerator, null, autoReconnect)
+  const tokenGenerator = () => Director.getSubscriber(streamName, streamAccountId)
+  const millicastView = new View(streamName, tokenGenerator, null, autoReconnect)
   millicastView.on("broadcastEvent", (event) => {
     if (!autoReconnect) return;
   
@@ -211,8 +211,8 @@ window['__onGCastApiAvailable'] = function(isAvailable) {
 
     if (castState === cast.framework.CastState.CONNECTED) {
       const castSession = castContext.getCurrentSession()
-      const mediaInfo = new chrome.cast.media.MediaInfo(streamId, '')
-      mediaInfo.customData = { streamId, streamAccountId }
+      const mediaInfo = new chrome.cast.media.MediaInfo(streamName, '')
+      mediaInfo.customData = { streamName, streamAccountId }
       mediaInfo.streamType = chrome.cast.media.StreamType.LIVE
 
       const loadRequest = new chrome.cast.media.LoadRequest(mediaInfo)


### PR DESCRIPTION
Due to #62 issue, we update the variable names.
- Renamed MILLICAST_STREAM_ID environment variables to MILLICAST_STREAM_NAME.
- Changed streamId variables to streamName.
- Updated documentation.