### PR TITLE
Fix: Set multiopus if current MediaStream has more than 2 channels.

### DIFF
--- a/packages/millicast-sdk/src/PeerConnection.js
+++ b/packages/millicast-sdk/src/PeerConnection.js
@@ -185,7 +185,7 @@ export default class PeerConnection extends EventEmitter {
     logger.debug('Peer offer response: ', response.sdp)
 
     this.sessionDescription = response
-    this.sessionDescription.sdp = SdpParser.setMultiopus(this.sessionDescription.sdp)
+    this.sessionDescription.sdp = SdpParser.setMultiopus(this.sessionDescription.sdp, mediaStream)
     if (options.simulcast) {
       this.sessionDescription.sdp = SdpParser.setSimulcast(this.sessionDescription.sdp, options.codec)
     }

--- a/packages/millicast-sdk/src/utils/SdpParser.js
+++ b/packages/millicast-sdk/src/utils/SdpParser.js
@@ -172,12 +172,13 @@ export default class SdpParser {
    *
    * **Only available in Google Chrome.**
    * @param {String} sdp - Current SDP.
+   * @param {MediaStream} mediaStream - MediaStream offered in the stream.
    * @returns {String} SDP parsed with multiopus support.
-   * @example SdpParser.setMultiopus(sdp)
+   * @example SdpParser.setMultiopus(sdp, mediaStream)
    */
-  static setMultiopus (sdp) {
+  static setMultiopus (sdp, mediaStream) {
     const browserData = new UserAgent()
-    if (browserData.isChrome()) {
+    if (browserData.isChrome() && (!mediaStream || hasAudioMultichannel(mediaStream))) {
       if (!sdp.includes('multiopus/48000/6')) {
         logger.info('Setting multiopus')
         // Find the audio m-line
@@ -220,4 +221,13 @@ export default class SdpParser {
 
     return ptAvailable
   }
+}
+
+/**
+ * Checks if mediaStream has more than 2 audio channels.
+ * @param {MediaStream} mediaStream - MediaStream to verify.
+ * @returns {Boolean} returns true if MediaStream has more than 2 channels.
+ */
+const hasAudioMultichannel = (mediaStream) => {
+  return !!mediaStream.getAudioTracks().find(value => value.getSettings().channelCount > 2)
 }

--- a/packages/millicast-sdk/src/utils/SdpParser.js
+++ b/packages/millicast-sdk/src/utils/SdpParser.js
@@ -229,5 +229,5 @@ export default class SdpParser {
  * @returns {Boolean} returns true if MediaStream has more than 2 channels.
  */
 const hasAudioMultichannel = (mediaStream) => {
-  return !!mediaStream.getAudioTracks().find(value => value.getSettings().channelCount > 2)
+  return mediaStream.getAudioTracks().some(value => value.getSettings().channelCount > 2)
 }

--- a/packages/millicast-sdk/tests/features/SdpMultiopus.feature
+++ b/packages/millicast-sdk/tests/features/SdpMultiopus.feature
@@ -1,8 +1,18 @@
 Feature: As a user I want to set multiopus in my SDP so I can offer surround to my peer
 
-  Scenario: Set multiopus in Chrome
+  Scenario: Set multiopus in Chrome and multichannel media stream
     Given I have a sdp and I am using Chrome
-    When I want to set multiopus
+    When I want to set multiopus with multichannel media stream
+    Then returns the sdp with multiopus updated
+
+  Scenario: Set multiopus in Chrome and monochannel media stream
+    Given I have a sdp and I am using Chrome
+    When I want to set multiopus with monochannel media stream
+    Then returns the sdp without multiopus
+  
+  Scenario: Set multiopus in Chrome and no media stream
+    Given I have a sdp and I am using Chrome
+    When I want to set multiopus with no media stream
     Then returns the sdp with multiopus updated
 
   Scenario: Set multiopus again in Chrome

--- a/packages/millicast-sdk/tests/features/step-definitions/SdpMultiopus.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/SdpMultiopus.steps.js
@@ -1,5 +1,6 @@
 import { loadFeature, defineFeature } from 'jest-cucumber'
 import SdpParser from '../../../src/utils/SdpParser'
+import './__mocks__/MockMediaStream'
 import { changeBrowserMock } from './__mocks__/MockBrowser'
 const feature = loadFeature('../SdpMultiopus.feature', { loadRelativePath: true, errors: true })
 
@@ -8,7 +9,7 @@ defineFeature(feature, test => {
     changeBrowserMock('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36')
   })
 
-  test('Set multiopus in Chrome', ({ given, when, then }) => {
+  test('Set multiopus in Chrome and multichannel media stream', ({ given, when, then }) => {
     let localSdp
     let multiopusSdp
 
@@ -17,8 +18,54 @@ defineFeature(feature, test => {
       expect(localSdp).toEqual(expect.not.stringContaining('multiopus/48000/6'))
     })
 
-    when('I want to set multiopus', async () => {
-      multiopusSdp = SdpParser.setMultiopus(localSdp)
+    when('I want to set multiopus with multichannel media stream', async () => {
+      const tracks = [
+        { id: 1, kind: 'audio', label: 'Audio1', getSettings: () => { return { channelCount: 4 } } },
+        { id: 2, kind: 'video', label: 'Video1' }]
+      const mediaStream = new MediaStream(tracks)
+      multiopusSdp = SdpParser.setMultiopus(localSdp, mediaStream)
+    })
+
+    then('returns the sdp with multiopus updated', async () => {
+      expect(multiopusSdp).not.toBe(localSdp)
+      expect(multiopusSdp).toMatch('multiopus/48000/6')
+    })
+  })
+
+  test('Set multiopus in Chrome and monochannel media stream', ({ given, when, then }) => {
+    let localSdp
+    let multiopusSdp
+
+    given('I have a sdp and I am using Chrome', async () => {
+      localSdp = 'v=0\r\no=- 6951551582290178118 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=group:BUNDLE 0 1\r\na=extmap-allow-mixed\r\na=msid-semantic: WMS Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\r\nc=IN IP4 0.0.0.0\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:47zq\r\na=ice-pwd:L1hL3yV+MsLmlx/yuN31ApfQ\r\na=ice-options:trickle\r\na=fingerprint:sha-256 EA:A4:8E:38:4A:31:61:A2:59:78:EB:AD:2E:77:3F:C0:BA:D1:13:93:0A:F3:4F:32:AB:8A:3A:E0:10:4E:95:C3\r\na=setup:actpass\r\na=mid:0\r\na=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\na=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\na=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\na=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid\r\na=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\r\na=extmap:6 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id\r\na=sendrecv\r\na=msid:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0 adb18b70-1d59-41e0-a080-f6e57efeac19\r\na=rtcp-mux\r\na=rtpmap:111 opus/48000/2\r\na=rtcp-fb:111 transport-cc\r\na=fmtp:111 minptime=10;useinbandfec=1\r\na=rtpmap:103 ISAC/16000\r\na=rtpmap:104 ISAC/32000\r\na=rtpmap:9 G722/8000\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:106 CN/32000\r\na=rtpmap:105 CN/16000\r\na=rtpmap:13 CN/8000\r\na=rtpmap:110 telephone-event/48000\r\na=rtpmap:112 telephone-event/32000\r\na=rtpmap:113 telephone-event/16000\r\na=rtpmap:126 telephone-event/8000\r\na=ssrc:2213016228 cname:uMbjTBwYv//E4gZM\r\na=ssrc:2213016228 msid:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0 adb18b70-1d59-41e0-a080-f6e57efeac19\r\na=ssrc:2213016228 mslabel:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0\r\na=ssrc:2213016228 label:adb18b70-1d59-41e0-a080-f6e57efeac19\r\nm=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 102 121 127 120 125 107 108 109 35 36 124 119 123 118 114 115 116\r\nc=IN IP4 0.0.0.0\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:47zq\r\na=ice-pwd:L1hL3yV+MsLmlx/yuN31ApfQ\r\na=ice-options:trickle\r\na=fingerprint:sha-256 EA:A4:8E:38:4A:31:61:A2:59:78:EB:AD:2E:77:3F:C0:BA:D1:13:93:0A:F3:4F:32:AB:8A:3A:E0:10:4E:95:C3\r\na=setup:actpass\r\na=mid:1\r\na=extmap:14 urn:ietf:params:rtp-hdrext:toffset\r\na=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\na=extmap:13 urn:3gpp:video-orientation\r\na=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\na=extmap:12 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay\r\na=extmap:11 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type\r\na=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-timing\r\na=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/color-space\r\na=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid\r\na=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\r\na=extmap:6 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id\r\na=sendrecv\r\na=msid:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0 306ab058-0f3b-4a6d-a039-d7495360c506\r\na=rtcp-mux\r\na=rtcp-rsize\r\na=rtpmap:96 VP8/90000\r\na=rtcp-fb:96 goog-remb\r\na=rtcp-fb:96 transport-cc\r\na=rtcp-fb:96 ccm fir\r\na=rtcp-fb:96 nack\r\na=rtcp-fb:96 nack pli\r\na=rtpmap:97 rtx/90000\r\na=fmtp:97 apt=96\r\na=rtpmap:98 VP9/90000\r\na=rtcp-fb:98 goog-remb\r\na=rtcp-fb:98 transport-cc\r\na=rtcp-fb:98 ccm fir\r\na=rtcp-fb:98 nack\r\na=rtcp-fb:98 nack pli\r\na=fmtp:98 profile-id=0\r\na=rtpmap:99 rtx/90000\r\na=fmtp:99 apt=98\r\na=rtpmap:100 VP9/90000\r\na=rtcp-fb:100 goog-remb\r\na=rtcp-fb:100 transport-cc\r\na=rtcp-fb:100 ccm fir\r\na=rtcp-fb:100 nack\r\na=rtcp-fb:100 nack pli\r\na=fmtp:100 profile-id=2\r\na=rtpmap:101 rtx/90000\r\na=fmtp:101 apt=100\r\na=rtpmap:102 H264/90000\r\na=rtcp-fb:102 goog-remb\r\na=rtcp-fb:102 transport-cc\r\na=rtcp-fb:102 ccm fir\r\na=rtcp-fb:102 nack\r\na=rtcp-fb:102 nack pli\r\na=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f\r\na=rtpmap:121 rtx/90000\r\na=fmtp:121 apt=102\r\na=rtpmap:127 H264/90000\r\na=rtcp-fb:127 goog-remb\r\na=rtcp-fb:127 transport-cc\r\na=rtcp-fb:127 ccm fir\r\na=rtcp-fb:127 nack\r\na=rtcp-fb:127 nack pli\r\na=fmtp:127 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f\r\na=rtpmap:120 rtx/90000\r\na=fmtp:120 apt=127\r\na=rtpmap:125 H264/90000\r\na=rtcp-fb:125 goog-remb\r\na=rtcp-fb:125 transport-cc\r\na=rtcp-fb:125 ccm fir\r\na=rtcp-fb:125 nack\r\na=rtcp-fb:125 nack pli\r\na=fmtp:125 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r\na=rtpmap:107 rtx/90000\r\na=fmtp:107 apt=125\r\na=rtpmap:108 H264/90000\r\na=rtcp-fb:108 goog-remb\r\na=rtcp-fb:108 transport-cc\r\na=rtcp-fb:108 ccm fir\r\na=rtcp-fb:108 nack\r\na=rtcp-fb:108 nack pli\r\na=fmtp:108 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f\r\na=rtpmap:109 rtx/90000\r\na=fmtp:109 apt=108\r\na=rtpmap:35 AV1X/90000\r\na=rtcp-fb:35 goog-remb\r\na=rtcp-fb:35 transport-cc\r\na=rtcp-fb:35 ccm fir\r\na=rtcp-fb:35 nack\r\na=rtcp-fb:35 nack pli\r\na=rtpmap:36 rtx/90000\r\na=fmtp:36 apt=35\r\na=rtpmap:124 H264/90000\r\na=rtcp-fb:124 goog-remb\r\na=rtcp-fb:124 transport-cc\r\na=rtcp-fb:124 ccm fir\r\na=rtcp-fb:124 nack\r\na=rtcp-fb:124 nack pli\r\na=fmtp:124 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f\r\na=rtpmap:119 rtx/90000\r\na=fmtp:119 apt=124\r\na=rtpmap:123 H264/90000\r\na=rtcp-fb:123 goog-remb\r\na=rtcp-fb:123 transport-cc\r\na=rtcp-fb:123 ccm fir\r\na=rtcp-fb:123 nack\r\na=rtcp-fb:123 nack pli\r\na=fmtp:123 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=64001f\r\na=rtpmap:118 rtx/90000\r\na=fmtp:118 apt=123\r\na=rtpmap:114 red/90000\r\na=rtpmap:115 rtx/90000\r\na=fmtp:115 apt=114\r\na=rtpmap:116 ulpfec/90000\r\na=ssrc-group:FID 3413953811 262260280\r\na=ssrc:3413953811 cname:uMbjTBwYv//E4gZM\r\na=ssrc:3413953811 msid:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0 306ab058-0f3b-4a6d-a039-d7495360c506\r\na=ssrc:3413953811 mslabel:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0\r\na=ssrc:3413953811 label:306ab058-0f3b-4a6d-a039-d7495360c506\r\na=ssrc:262260280 cname:uMbjTBwYv//E4gZM\r\na=ssrc:262260280 msid:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0 306ab058-0f3b-4a6d-a039-d7495360c506\r\na=ssrc:262260280 mslabel:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0\r\na=ssrc:262260280 label:306ab058-0f3b-4a6d-a039-d7495360c506\r\n'
+      expect(localSdp).toEqual(expect.not.stringContaining('multiopus/48000/6'))
+    })
+
+    when('I want to set multiopus with monochannel media stream', async () => {
+      const tracks = [
+        { id: 1, kind: 'audio', label: 'Audio1', getSettings: () => { return { channelCount: 1 } } },
+        { id: 2, kind: 'video', label: 'Video1' }]
+      const mediaStream = new MediaStream(tracks)
+      multiopusSdp = SdpParser.setMultiopus(localSdp, mediaStream)
+    })
+
+    then('returns the sdp without multiopus', async () => {
+      expect(multiopusSdp).toBe(localSdp)
+      expect(multiopusSdp).not.toMatch('multiopus/48000/6')
+    })
+  })
+
+  test('Set multiopus in Chrome and no media stream', ({ given, when, then }) => {
+    let localSdp
+    let multiopusSdp
+
+    given('I have a sdp and I am using Chrome', async () => {
+      localSdp = 'v=0\r\no=- 6951551582290178118 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=group:BUNDLE 0 1\r\na=extmap-allow-mixed\r\na=msid-semantic: WMS Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111 103 104 9 0 8 106 105 13 110 112 113 126\r\nc=IN IP4 0.0.0.0\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:47zq\r\na=ice-pwd:L1hL3yV+MsLmlx/yuN31ApfQ\r\na=ice-options:trickle\r\na=fingerprint:sha-256 EA:A4:8E:38:4A:31:61:A2:59:78:EB:AD:2E:77:3F:C0:BA:D1:13:93:0A:F3:4F:32:AB:8A:3A:E0:10:4E:95:C3\r\na=setup:actpass\r\na=mid:0\r\na=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level\r\na=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\na=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\na=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid\r\na=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\r\na=extmap:6 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id\r\na=sendrecv\r\na=msid:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0 adb18b70-1d59-41e0-a080-f6e57efeac19\r\na=rtcp-mux\r\na=rtpmap:111 opus/48000/2\r\na=rtcp-fb:111 transport-cc\r\na=fmtp:111 minptime=10;useinbandfec=1\r\na=rtpmap:103 ISAC/16000\r\na=rtpmap:104 ISAC/32000\r\na=rtpmap:9 G722/8000\r\na=rtpmap:0 PCMU/8000\r\na=rtpmap:8 PCMA/8000\r\na=rtpmap:106 CN/32000\r\na=rtpmap:105 CN/16000\r\na=rtpmap:13 CN/8000\r\na=rtpmap:110 telephone-event/48000\r\na=rtpmap:112 telephone-event/32000\r\na=rtpmap:113 telephone-event/16000\r\na=rtpmap:126 telephone-event/8000\r\na=ssrc:2213016228 cname:uMbjTBwYv//E4gZM\r\na=ssrc:2213016228 msid:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0 adb18b70-1d59-41e0-a080-f6e57efeac19\r\na=ssrc:2213016228 mslabel:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0\r\na=ssrc:2213016228 label:adb18b70-1d59-41e0-a080-f6e57efeac19\r\nm=video 9 UDP/TLS/RTP/SAVPF 96 97 98 99 100 101 102 121 127 120 125 107 108 109 35 36 124 119 123 118 114 115 116\r\nc=IN IP4 0.0.0.0\r\na=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:47zq\r\na=ice-pwd:L1hL3yV+MsLmlx/yuN31ApfQ\r\na=ice-options:trickle\r\na=fingerprint:sha-256 EA:A4:8E:38:4A:31:61:A2:59:78:EB:AD:2E:77:3F:C0:BA:D1:13:93:0A:F3:4F:32:AB:8A:3A:E0:10:4E:95:C3\r\na=setup:actpass\r\na=mid:1\r\na=extmap:14 urn:ietf:params:rtp-hdrext:toffset\r\na=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\na=extmap:13 urn:3gpp:video-orientation\r\na=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01\r\na=extmap:12 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay\r\na=extmap:11 http://www.webrtc.org/experiments/rtp-hdrext/video-content-type\r\na=extmap:7 http://www.webrtc.org/experiments/rtp-hdrext/video-timing\r\na=extmap:8 http://www.webrtc.org/experiments/rtp-hdrext/color-space\r\na=extmap:4 urn:ietf:params:rtp-hdrext:sdes:mid\r\na=extmap:5 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id\r\na=extmap:6 urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id\r\na=sendrecv\r\na=msid:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0 306ab058-0f3b-4a6d-a039-d7495360c506\r\na=rtcp-mux\r\na=rtcp-rsize\r\na=rtpmap:96 VP8/90000\r\na=rtcp-fb:96 goog-remb\r\na=rtcp-fb:96 transport-cc\r\na=rtcp-fb:96 ccm fir\r\na=rtcp-fb:96 nack\r\na=rtcp-fb:96 nack pli\r\na=rtpmap:97 rtx/90000\r\na=fmtp:97 apt=96\r\na=rtpmap:98 VP9/90000\r\na=rtcp-fb:98 goog-remb\r\na=rtcp-fb:98 transport-cc\r\na=rtcp-fb:98 ccm fir\r\na=rtcp-fb:98 nack\r\na=rtcp-fb:98 nack pli\r\na=fmtp:98 profile-id=0\r\na=rtpmap:99 rtx/90000\r\na=fmtp:99 apt=98\r\na=rtpmap:100 VP9/90000\r\na=rtcp-fb:100 goog-remb\r\na=rtcp-fb:100 transport-cc\r\na=rtcp-fb:100 ccm fir\r\na=rtcp-fb:100 nack\r\na=rtcp-fb:100 nack pli\r\na=fmtp:100 profile-id=2\r\na=rtpmap:101 rtx/90000\r\na=fmtp:101 apt=100\r\na=rtpmap:102 H264/90000\r\na=rtcp-fb:102 goog-remb\r\na=rtcp-fb:102 transport-cc\r\na=rtcp-fb:102 ccm fir\r\na=rtcp-fb:102 nack\r\na=rtcp-fb:102 nack pli\r\na=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f\r\na=rtpmap:121 rtx/90000\r\na=fmtp:121 apt=102\r\na=rtpmap:127 H264/90000\r\na=rtcp-fb:127 goog-remb\r\na=rtcp-fb:127 transport-cc\r\na=rtcp-fb:127 ccm fir\r\na=rtcp-fb:127 nack\r\na=rtcp-fb:127 nack pli\r\na=fmtp:127 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f\r\na=rtpmap:120 rtx/90000\r\na=fmtp:120 apt=127\r\na=rtpmap:125 H264/90000\r\na=rtcp-fb:125 goog-remb\r\na=rtcp-fb:125 transport-cc\r\na=rtcp-fb:125 ccm fir\r\na=rtcp-fb:125 nack\r\na=rtcp-fb:125 nack pli\r\na=fmtp:125 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f\r\na=rtpmap:107 rtx/90000\r\na=fmtp:107 apt=125\r\na=rtpmap:108 H264/90000\r\na=rtcp-fb:108 goog-remb\r\na=rtcp-fb:108 transport-cc\r\na=rtcp-fb:108 ccm fir\r\na=rtcp-fb:108 nack\r\na=rtcp-fb:108 nack pli\r\na=fmtp:108 level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42e01f\r\na=rtpmap:109 rtx/90000\r\na=fmtp:109 apt=108\r\na=rtpmap:35 AV1X/90000\r\na=rtcp-fb:35 goog-remb\r\na=rtcp-fb:35 transport-cc\r\na=rtcp-fb:35 ccm fir\r\na=rtcp-fb:35 nack\r\na=rtcp-fb:35 nack pli\r\na=rtpmap:36 rtx/90000\r\na=fmtp:36 apt=35\r\na=rtpmap:124 H264/90000\r\na=rtcp-fb:124 goog-remb\r\na=rtcp-fb:124 transport-cc\r\na=rtcp-fb:124 ccm fir\r\na=rtcp-fb:124 nack\r\na=rtcp-fb:124 nack pli\r\na=fmtp:124 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f\r\na=rtpmap:119 rtx/90000\r\na=fmtp:119 apt=124\r\na=rtpmap:123 H264/90000\r\na=rtcp-fb:123 goog-remb\r\na=rtcp-fb:123 transport-cc\r\na=rtcp-fb:123 ccm fir\r\na=rtcp-fb:123 nack\r\na=rtcp-fb:123 nack pli\r\na=fmtp:123 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=64001f\r\na=rtpmap:118 rtx/90000\r\na=fmtp:118 apt=123\r\na=rtpmap:114 red/90000\r\na=rtpmap:115 rtx/90000\r\na=fmtp:115 apt=114\r\na=rtpmap:116 ulpfec/90000\r\na=ssrc-group:FID 3413953811 262260280\r\na=ssrc:3413953811 cname:uMbjTBwYv//E4gZM\r\na=ssrc:3413953811 msid:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0 306ab058-0f3b-4a6d-a039-d7495360c506\r\na=ssrc:3413953811 mslabel:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0\r\na=ssrc:3413953811 label:306ab058-0f3b-4a6d-a039-d7495360c506\r\na=ssrc:262260280 cname:uMbjTBwYv//E4gZM\r\na=ssrc:262260280 msid:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0 306ab058-0f3b-4a6d-a039-d7495360c506\r\na=ssrc:262260280 mslabel:Z1VOhybPunxH0OkYHSjWfuVeQS0hP7KE2VF0\r\na=ssrc:262260280 label:306ab058-0f3b-4a6d-a039-d7495360c506\r\n'
+      expect(localSdp).toEqual(expect.not.stringContaining('multiopus/48000/6'))
+    })
+
+    when('I want to set multiopus with no media stream', async () => {
+      multiopusSdp = SdpParser.setMultiopus(localSdp, null)
     })
 
     then('returns the sdp with multiopus updated', async () => {
@@ -40,7 +87,7 @@ defineFeature(feature, test => {
     })
 
     when('I want to set multiopus', async () => {
-      repeatedMultiOpusSDP = SdpParser.setMultiopus(multiopusSdp)
+      repeatedMultiOpusSDP = SdpParser.setMultiopus(multiopusSdp, null)
     })
 
     then('returns the same sdp', async () => {
@@ -60,7 +107,7 @@ defineFeature(feature, test => {
     })
 
     when('I want to set multiopus', async () => {
-      multiopusSdp = SdpParser.setMultiopus(localSdp)
+      multiopusSdp = SdpParser.setMultiopus(localSdp, null)
     })
 
     then('returns the sdp without multiopus', async () => {
@@ -79,7 +126,7 @@ defineFeature(feature, test => {
     })
 
     when('I want to set multiopus', async () => {
-      multiopusSdp = SdpParser.setMultiopus(localSdp)
+      multiopusSdp = SdpParser.setMultiopus(localSdp, null)
     })
 
     then('returns the sdp without multiopus', async () => {

--- a/packages/millicast-sdk/tests/features/step-definitions/__mocks__/MockMediaStream.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/__mocks__/MockMediaStream.js
@@ -1,7 +1,10 @@
 export default class MockMediaStream {
   constructor (tracks = []) {
-    this.audioTracks = tracks.filter(x => x.kind === 'audio') ?? []
-    this.videoTracks = tracks.filter(x => x.kind === 'video') ?? []
+    this.audioTracks = []
+    this.videoTracks = []
+    for (const track of tracks) {
+      this.addTrack(track)
+    }
   }
 
   getAudioTracks () {
@@ -17,11 +20,19 @@ export default class MockMediaStream {
   }
 
   addTrack (track) {
+    const trackParsed = track
+    trackParsed.getSettings = trackParsed.getSettings ?? getSettings
     if (track.kind === 'audio') {
-      this.audioTracks.push(track)
+      this.audioTracks.push(trackParsed)
     } else {
-      this.videoTracks.push(track)
+      this.videoTracks.push(trackParsed)
     }
+  }
+}
+
+const getSettings = () => {
+  return {
+    channelCount: 0
   }
 }
 

--- a/packages/millicast-sdk/tests/functional/utils/env-sample.js
+++ b/packages/millicast-sdk/tests/functional/utils/env-sample.js
@@ -1,4 +1,0 @@
-// For use functional manual tests, create an env.js with the following credentials.
-window.accountId = ''
-window.streamName = ''
-window.token = ''

--- a/packages/millicast-sdk/tests/functional/utils/test-enviroment-sample.js
+++ b/packages/millicast-sdk/tests/functional/utils/test-enviroment-sample.js
@@ -1,0 +1,4 @@
+// For use functional manual tests, create a test-enviroment.js with the following credentials.
+window.accountId = ''
+window.streamName = ''
+window.token = ''


### PR DESCRIPTION
Due to #65, we set multiopus in the SDP if MediaStream is multichannel or is a Viewer (no MediaStream).
Added scenarios and tests.
Renamed env-sample variables to test-enviroment-samples.