### PR TITLE
Feature: Refactor getRTCPeer

### DIFF
--- a/packages/millicast-sdk/src/PeerConnection.js
+++ b/packages/millicast-sdk/src/PeerConnection.js
@@ -41,21 +41,27 @@ export default class PeerConnection extends EventEmitter {
   }
 
   /**
-   * Get current RTC peer connection or establish a new connection.
+   * Instance new RTCPeerConnection.
    * @param {RTCConfiguration} config - Peer configuration.
-   * @returns {Promise<RTCPeerConnection>} Promise object which represents the RTCPeerConnection.
    */
-  async getRTCPeer (config = null) {
-    logger.info('Getting RTC Peer')
+  async createRTCPeer (config = null) {
+    logger.info('Creating new RTCPeerConnection')
     logger.debug('RTC configuration provided by user: ', config)
-    if (!this.peer) {
-      config = await this.getRTCConfiguration(config)
-      this.peer = instanceRTCPeerConnection(this, config)
-    }
+    config = await this.getRTCConfiguration(config)
+    this.peer = instanceRTCPeerConnection(this, config)
+  }
 
-    const connectionState = getConnectionState(this.peer)
-    const { currentLocalDescription, currentRemoteDescription } = this.peer
-    logger.debug('getRTCPeer return: ', { connectionState, currentLocalDescription, currentRemoteDescription })
+  /**
+   * Get current RTC peer connection.
+   * @returns {RTCPeerConnection} Object which represents the RTCPeerConnection.
+   */
+  getRTCPeer () {
+    logger.info('Getting RTC Peer')
+    if (this.peer) {
+      const connectionState = getConnectionState(this.peer)
+      const { currentLocalDescription, currentRemoteDescription } = this.peer
+      logger.debug('getRTCPeer return: ', { connectionState, currentLocalDescription, currentRemoteDescription })
+    }
     return this.peer
   }
 

--- a/packages/millicast-sdk/src/PeerConnection.js
+++ b/packages/millicast-sdk/src/PeerConnection.js
@@ -49,10 +49,7 @@ export default class PeerConnection extends EventEmitter {
     logger.info('Getting RTC Peer')
     logger.debug('RTC configuration provided by user: ', config)
     if (!this.peer) {
-      if (!config) {
-        logger.info('RTC configuration not provided by user.')
-        config = await this.getRTCConfiguration()
-      }
+      config = await this.getRTCConfiguration(config)
       this.peer = instanceRTCPeerConnection(this, config)
     }
 
@@ -75,13 +72,15 @@ export default class PeerConnection extends EventEmitter {
   }
 
   /**
-   * Get RTC configurations with ICE servers get from Milicast signaling server.
+   * Get default RTC configuration with ICE servers from Milicast signaling server and merge it with the user configuration provided. User configuration has priority over defaults.
+   * @param {RTCConfiguration} config - Options to configure the new RTCPeerConnection.
    * @returns {Promise<RTCConfiguration>} Promise object which represents the RTCConfiguration.
    */
-  async getRTCConfiguration () {
+  async getRTCConfiguration (config) {
     logger.info('Getting RTC configuration')
-    const iceServers = await this.getRTCIceServers()
-    return { iceServers }
+    const configParsed = config ?? {}
+    configParsed.iceServers = configParsed.iceServers ?? await this.getRTCIceServers()
+    return configParsed
   }
 
   /**

--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -13,7 +13,7 @@ const connectOptions = {
   codec: VideoCodec.H264,
   simulcast: false,
   scalabilityMode: null,
-  peerOptions: null
+  peerConfig: null
 }
 
 /**
@@ -51,7 +51,7 @@ export default class Publish extends BaseWebRTC {
    * @param {Boolean} options.simulcast - Enable simulcast. **Only available in Google Chrome and with H.264 or VP8 video codecs.**
    * @param {String} options.scalabilityMode - Selected scalability mode. You can get the available capabilities using <a href="PeerConnection#.getCapabilities">PeerConnection.getCapabilities</a> method.
    * **Only available in Google Chrome.**
-   * @param {RTCConfiguration} options.peerOptions - Options to configure the new RTCPeerConnection.
+   * @param {RTCConfiguration} options.peerConfig - Options to configure the new RTCPeerConnection.
    * @returns {Promise<void>} Promise object which resolves when the broadcast started successfully.
    * @fires PeerConnection#connectionStateChange
    * @example await publish.connect(options)
@@ -107,7 +107,7 @@ export default class Publish extends BaseWebRTC {
       url: `${publisherData.urls[0]}?token=${publisherData.jwt}`
     })
 
-    await this.webRTCPeer.createRTCPeer(this.options.peerOptions)
+    await this.webRTCPeer.createRTCPeer(this.options.peerConfig)
     reemit(this.webRTCPeer, this, [webRTCEvents.connectionStateChange])
 
     const localSdp = await this.webRTCPeer.getRTCLocalSDP(this.options)

--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -12,7 +12,8 @@ const connectOptions = {
   disableAudio: false,
   codec: VideoCodec.H264,
   simulcast: false,
-  scalabilityMode: null
+  scalabilityMode: null,
+  peerOptions: null
 }
 
 /**
@@ -50,6 +51,7 @@ export default class Publish extends BaseWebRTC {
    * @param {Boolean} options.simulcast - Enable simulcast. **Only available in Google Chrome and with H.264 or VP8 video codecs.**
    * @param {String} options.scalabilityMode - Selected scalability mode. You can get the available capabilities using <a href="PeerConnection#.getCapabilities">PeerConnection.getCapabilities</a> method.
    * **Only available in Google Chrome.**
+   * @param {RTCConfiguration} options.peerOptions - Options to configure the new RTCPeerConnection.
    * @returns {Promise<void>} Promise object which resolves when the broadcast started successfully.
    * @fires PeerConnection#connectionStateChange
    * @example await publish.connect(options)
@@ -105,7 +107,7 @@ export default class Publish extends BaseWebRTC {
       url: `${publisherData.urls[0]}?token=${publisherData.jwt}`
     })
 
-    await this.webRTCPeer.getRTCPeer()
+    await this.webRTCPeer.getRTCPeer(this.options.peerOptions)
     reemit(this.webRTCPeer, this, [webRTCEvents.connectionStateChange])
 
     const localSdp = await this.webRTCPeer.getRTCLocalSDP(this.options)

--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -107,7 +107,7 @@ export default class Publish extends BaseWebRTC {
       url: `${publisherData.urls[0]}?token=${publisherData.jwt}`
     })
 
-    await this.webRTCPeer.getRTCPeer(this.options.peerOptions)
+    await this.webRTCPeer.createRTCPeer(this.options.peerOptions)
     reemit(this.webRTCPeer, this, [webRTCEvents.connectionStateChange])
 
     const localSdp = await this.webRTCPeer.getRTCLocalSDP(this.options)

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -113,7 +113,7 @@ export default class View extends BaseWebRTC {
       url: `${subscriberData.urls[0]}?token=${subscriberData.jwt}`
     })
 
-    await this.webRTCPeer.getRTCPeer(this.options.peerOptions)
+    await this.webRTCPeer.createRTCPeer(this.options.peerOptions)
     reemit(this.webRTCPeer, this, Object.values(webRTCEvents))
 
     const localSdp = await this.webRTCPeer.getRTCLocalSDP({ ...this.options, stereo: true })

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -8,7 +8,7 @@ const logger = Logger.get('View')
 const connectOptions = {
   disableVideo: false,
   disableAudio: false,
-  peerOptions: null
+  peerConfig: null
 }
 
 /**
@@ -43,7 +43,7 @@ export default class View extends BaseWebRTC {
    * @param {Object} options - General subscriber options.
    * @param {Boolean} [options.disableVideo = false] - Disable the opportunity to receive video stream.
    * @param {Boolean} [options.disableAudio = false] - Disable the opportunity to receive audio stream.
-   * @param {RTCConfiguration} options.peerOptions - Options to configure the new RTCPeerConnection.
+   * @param {RTCConfiguration} options.peerConfig - Options to configure the new RTCPeerConnection.
    * @returns {Promise<void>} Promise object which resolves when the connection was successfully established.
    * @fires PeerConnection#track
    * @fires Signaling#broadcastEvent
@@ -113,7 +113,7 @@ export default class View extends BaseWebRTC {
       url: `${subscriberData.urls[0]}?token=${subscriberData.jwt}`
     })
 
-    await this.webRTCPeer.createRTCPeer(this.options.peerOptions)
+    await this.webRTCPeer.createRTCPeer(this.options.peerConfig)
     reemit(this.webRTCPeer, this, Object.values(webRTCEvents))
 
     const localSdp = await this.webRTCPeer.getRTCLocalSDP({ ...this.options, stereo: true })

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -7,7 +7,8 @@ const logger = Logger.get('View')
 
 const connectOptions = {
   disableVideo: false,
-  disableAudio: false
+  disableAudio: false,
+  peerOptions: null
 }
 
 /**
@@ -42,6 +43,7 @@ export default class View extends BaseWebRTC {
    * @param {Object} options - General subscriber options.
    * @param {Boolean} [options.disableVideo = false] - Disable the opportunity to receive video stream.
    * @param {Boolean} [options.disableAudio = false] - Disable the opportunity to receive audio stream.
+   * @param {RTCConfiguration} options.peerOptions - Options to configure the new RTCPeerConnection.
    * @returns {Promise<void>} Promise object which resolves when the connection was successfully established.
    * @fires PeerConnection#track
    * @fires Signaling#broadcastEvent
@@ -111,7 +113,7 @@ export default class View extends BaseWebRTC {
       url: `${subscriberData.urls[0]}?token=${subscriberData.jwt}`
     })
 
-    await this.webRTCPeer.getRTCPeer()
+    await this.webRTCPeer.getRTCPeer(this.options.peerOptions)
     reemit(this.webRTCPeer, this, Object.values(webRTCEvents))
 
     const localSdp = await this.webRTCPeer.getRTCLocalSDP({ ...this.options, stereo: true })

--- a/packages/millicast-sdk/tests/features/ManagePeerConnection.feature
+++ b/packages/millicast-sdk/tests/features/ManagePeerConnection.feature
@@ -4,11 +4,11 @@ Feature: As a user I want to manage the peer connection so I can initialize a We
     Given I have no configuration
     When I get the RTC peer
     Then returns the peer
-  
-  Scenario: Get RTC peer again
-    Given I got the peer previously
-    When I get the RTC peer
-    Then returns the peer
+
+  Scenario: Get RTC peer without instance previously
+    Given I have no configuration
+    When I get the RTC peer without instance first
+    Then returns null
 
   Scenario: Get RTC peer with configuration
     Given I have configuration

--- a/packages/millicast-sdk/tests/features/step-definitions/ChangeMediaTrack.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/ChangeMediaTrack.steps.js
@@ -19,7 +19,7 @@ defineFeature(feature, test => {
     const track = { id: 3, kind: 'audio', label: 'Audio2' }
 
     given('I have a peer connected', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       const tracks = [{ id: 1, kind: 'audio', label: 'Audio1' }, { id: 2, kind: 'video', label: 'Video1' }]
       const mediaStream = new MediaStream(tracks)
       await peerConnection.getRTCLocalSDP({ mediaStream, disableVideo: false, disableAudio: false })
@@ -61,7 +61,7 @@ defineFeature(feature, test => {
     const track = { id: 2, kind: 'audio', label: 'Audio2' }
 
     given('I have a peer connected with video track', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       const tracks = [{ id: 1, kind: 'video', label: 'Video1' }]
       const mediaStream = new MediaStream(tracks)
       await peerConnection.getRTCLocalSDP({ mediaStream })

--- a/packages/millicast-sdk/tests/features/step-definitions/GetPeerStatus.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/GetPeerStatus.steps.js
@@ -19,7 +19,7 @@ defineFeature(feature, test => {
     let status
 
     given('I have a peer instanced', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
     })
 
     when('I want to get the peer connection state', () => {
@@ -52,7 +52,7 @@ defineFeature(feature, test => {
 
     given('I have a peer connecting without connectionState', async () => {
       global.RTCPeerConnection = MockRTCPeerConnectionNoConnectionState
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       peerConnection.peer.iceConnectionState = 'checking'
     })
 
@@ -71,7 +71,7 @@ defineFeature(feature, test => {
 
     given('I have a peer connected without connectionState', async () => {
       global.RTCPeerConnection = MockRTCPeerConnectionNoConnectionState
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       peerConnection.peer.iceConnectionState = 'completed'
     })
 

--- a/packages/millicast-sdk/tests/features/step-definitions/ManagePeerConnection.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/ManagePeerConnection.steps.js
@@ -23,7 +23,8 @@ defineFeature(feature, test => {
     })
 
     when('I get the RTC peer', async () => {
-      peer = await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
+      peer = peerConnection.getRTCPeer()
     })
 
     then('returns the peer', async () => {
@@ -31,22 +32,21 @@ defineFeature(feature, test => {
     })
   })
 
-  test('Get RTC peer again', ({ given, when, then }) => {
+  test('Get RTC peer without instance previously', ({ given, when, then }) => {
     let peerConnection = null
     let peer = null
 
-    given('I got the peer previously', async () => {
+    given('I have no configuration', async () => {
       jest.spyOn(PeerConnection.prototype, 'getRTCIceServers').mockReturnValue([])
       peerConnection = new PeerConnection()
-      await peerConnection.getRTCPeer()
     })
 
-    when('I get the RTC peer', async () => {
-      peer = await peerConnection.getRTCPeer()
+    when('I get the RTC peer without instance first', async () => {
+      peer = peerConnection.getRTCPeer()
     })
 
-    then('returns the peer', async () => {
-      expect(peer).toMatchObject(peerConnection.peer)
+    then('returns null', async () => {
+      expect(peer).toBeNull()
     })
   })
 
@@ -59,9 +59,10 @@ defineFeature(feature, test => {
     })
 
     when('I get the RTC peer', async () => {
-      peer = await peerConnection.getRTCPeer({
+      await peerConnection.createRTCPeer({
         bundlePolicy: 'max-bundle'
       })
+      peer = peerConnection.getRTCPeer()
     })
 
     then('returns the peer', async () => {
@@ -79,7 +80,7 @@ defineFeature(feature, test => {
     given('I have a RTC peer', async () => {
       jest.spyOn(PeerConnection.prototype, 'getRTCIceServers').mockReturnValue([])
       peerConnection = new PeerConnection()
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       peerConnection.on(webRTCEvents.connectionStateChange, handler)
     })
 

--- a/packages/millicast-sdk/tests/features/step-definitions/PeerConnectionEvent.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/PeerConnectionEvent.steps.js
@@ -20,7 +20,7 @@ defineFeature(feature, test => {
     const sdp = 'My default SDP'
 
     given('I have a peer connected', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       await peerConnection.setRTCRemoteSDP(sdp)
     })
 
@@ -41,7 +41,7 @@ defineFeature(feature, test => {
     const sdp = 'My default SDP'
 
     given('I have a peer', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
     })
 
     when('peer starts to connect', async () => {
@@ -63,7 +63,7 @@ defineFeature(feature, test => {
     const sdp = 'My default SDP'
 
     given('I have a peer', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
     })
 
     when('peer connects', async () => {
@@ -85,7 +85,7 @@ defineFeature(feature, test => {
     const sdp = 'My default SDP'
 
     given('I have a peer connected', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       await peerConnection.setRTCRemoteSDP(sdp)
       peerConnection.peer.connectionState = 'connected'
     })
@@ -108,7 +108,7 @@ defineFeature(feature, test => {
     const sdp = 'My default SDP'
 
     given('I have a peer connected', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       await peerConnection.setRTCRemoteSDP(sdp)
       peerConnection.peer.connectionState = 'connected'
     })
@@ -132,7 +132,7 @@ defineFeature(feature, test => {
 
     given('I have a peer without connectionState', async () => {
       global.RTCPeerConnection = MockRTCPeerConnectionNoConnectionState
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
     })
 
     when('peer is instanced', async () => {

--- a/packages/millicast-sdk/tests/features/step-definitions/SetLocalDescription.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/SetLocalDescription.steps.js
@@ -20,7 +20,7 @@ defineFeature(feature, test => {
     let sdp
 
     given('I do not have options', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
     })
 
     when('I want to get the RTC Local SDP', async () => {
@@ -38,7 +38,7 @@ defineFeature(feature, test => {
     let sdp
 
     given('I want local SDP without video', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
     })
 
     when('I want to get the RTC Local SDP', async () => {
@@ -56,7 +56,7 @@ defineFeature(feature, test => {
     let sdp
 
     given('I want local SDP without audio', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
     })
 
     when('I want to get the RTC Local SDP', async () => {
@@ -76,7 +76,7 @@ defineFeature(feature, test => {
     let stereo
 
     given('I have a MediaStream with 1 audio track and 1 video track and I want support stereo', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       const tracks = [{ id: 1, kind: 'audio', label: 'Audio1' }, { id: 2, kind: 'video', label: 'Video1' }]
       mediaStream = new MediaStream(tracks)
       stereo = true
@@ -99,7 +99,7 @@ defineFeature(feature, test => {
     let stereo
 
     given('I have a MediaStream with 1 audio track and 1 video track', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       const tracks = [{ id: 1, kind: 'audio', label: 'Audio1' }, { id: 2, kind: 'video', label: 'Video1' }]
       mediaStream = new MediaStream(tracks)
       stereo = true
@@ -122,7 +122,7 @@ defineFeature(feature, test => {
     let stereo
 
     given('I have a MediaStream with 1 audio track and 1 video track', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       const tracks = [{ id: 1, kind: 'audio', label: 'Audio1' }, { id: 2, kind: 'video', label: 'Video1' }]
       mediaStream = new MediaStream(tracks)
       stereo = true
@@ -145,7 +145,7 @@ defineFeature(feature, test => {
     let simulcast
 
     given('I have a MediaStream with 1 audio track and 1 video track and I want support simulcast', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       const tracks = [{ id: 1, kind: 'audio', label: 'Audio1' }, { id: 2, kind: 'video', label: 'Video1' }]
       mediaStream = new MediaStream(tracks)
       simulcast = true
@@ -168,7 +168,7 @@ defineFeature(feature, test => {
     let stereo
 
     given('I have a MediaStream with 2 video tracks and no audio track', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       const tracks = [{ id: 1, kind: 'video', label: 'Video1' }, { id: 2, kind: 'video', label: 'Video2' }]
       mediaStream = new MediaStream(tracks)
       stereo = true
@@ -193,7 +193,7 @@ defineFeature(feature, test => {
     let tracks
 
     given('I have a list of tracks with 1 audio track and 1 video track', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       tracks = [{ id: 1, kind: 'audio', label: 'Audio1' }, { id: 2, kind: 'video', label: 'Video1' }]
     })
 
@@ -213,7 +213,7 @@ defineFeature(feature, test => {
     let tracks
 
     given('I have a list of tracks with 3 audio tracks and 1 video track', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       tracks = [{ id: 1, kind: 'audio', label: 'Audio1' }, { id: 2, kind: 'video', label: 'Video1' },
         { id: 3, kind: 'audio', label: 'Audio2' }, { id: 4, kind: 'audio', label: 'Audio3' }]
     })
@@ -238,7 +238,7 @@ defineFeature(feature, test => {
     let scalabilityMode
 
     given('I am using Chrome and I have a MediaStream with 1 audio track and 1 video track and I want to support L1T3 mode', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       const tracks = [{ id: 1, kind: 'audio', label: 'Audio1' }, { id: 2, kind: 'video', label: 'Video1' }]
       mediaStream = new MediaStream(tracks)
       scalabilityMode = 'L1T3'
@@ -264,7 +264,7 @@ defineFeature(feature, test => {
 
     given('I am using Firefox and I have a MediaStream with 1 audio track and 1 video track and I want to support L1T3 mode', async () => {
       changeBrowserMock('Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0')
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       const tracks = [{ id: 1, kind: 'audio', label: 'Audio1' }, { id: 2, kind: 'video', label: 'Video1' }]
       mediaStream = new MediaStream(tracks)
       scalabilityMode = 'L1T3'

--- a/packages/millicast-sdk/tests/features/step-definitions/SetRemoteDescription.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/SetRemoteDescription.steps.js
@@ -19,7 +19,7 @@ defineFeature(feature, test => {
 
     given('I got the peer', async () => {
       jest.spyOn(PeerConnection.prototype, 'getRTCIceServers').mockReturnValue([])
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
     })
 
     when('I set the remote description', async () => {
@@ -38,7 +38,7 @@ defineFeature(feature, test => {
 
     given('I got the peer', async () => {
       jest.spyOn(PeerConnection.prototype, 'getRTCIceServers').mockReturnValue([])
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
     })
 
     when('I set the remote description and peer returns an error', async () => {

--- a/packages/millicast-sdk/tests/features/step-definitions/UpdateBitrateWebRTC.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/UpdateBitrateWebRTC.steps.js
@@ -20,7 +20,7 @@ defineFeature(feature, test => {
     const sdp = 'My default SDP'
 
     given('I have a peer connected', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       await peerConnection.setRTCRemoteSDP(sdp)
       expect(peerConnection.peer.currentRemoteDescription.sdp).toBe(sdp)
     })
@@ -39,7 +39,7 @@ defineFeature(feature, test => {
     const sdp = 'My default SDP'
 
     given('I have a peer connected', async () => {
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       await peerConnection.setRTCRemoteSDP(sdp)
       expect(peerConnection.peer.currentRemoteDescription.sdp).toBe(sdp)
     })
@@ -59,7 +59,7 @@ defineFeature(feature, test => {
 
     given('I am using Firefox and I have a peer connected', async () => {
       changeBrowserMock('Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0')
-      await peerConnection.getRTCPeer()
+      await peerConnection.createRTCPeer()
       await peerConnection.setRTCRemoteSDP(sdp)
       expect(peerConnection.peer.currentRemoteDescription.sdp).toBe(sdp)
     })


### PR DESCRIPTION
Due to issues #71 and #72:
- Added peerOptions into View and Publish broadcast options. You can add your own configuration for instance RTCPeerConnection.  If the iceServers option is not present, it will use our.
- Refactor: Separate getRTCPeer into two methods, one for get and other (createRTCPeer) for create it.