### PR TITLE
Feature: Record option refactor

### DIFF
--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -13,8 +13,7 @@ const connectOptions = {
   codec: VideoCodec.H264,
   simulcast: false,
   scalabilityMode: null,
-  peerConfig: null,
-  record: false
+  peerConfig: null
 }
 
 /**
@@ -53,7 +52,7 @@ export default class Publish extends BaseWebRTC {
    * @param {String} options.scalabilityMode - Selected scalability mode. You can get the available capabilities using <a href="PeerConnection#.getCapabilities">PeerConnection.getCapabilities</a> method.
    * **Only available in Google Chrome.**
    * @param {RTCConfiguration} options.peerConfig - Options to configure the new RTCPeerConnection.
-   * @param {Boolean} options.record - Enable stream recording. **Only available in Tokens with recording enabled.**
+   * @param {Boolean} [options.record] - Enable stream recording. If record is not provided, use default Token configuration. **Only available in Tokens with recording enabled.**
    * @returns {Promise<void>} Promise object which resolves when the broadcast started successfully.
    * @fires PeerConnection#connectionStateChange
    * @example await publish.connect(options)

--- a/packages/millicast-sdk/src/Signaling.js
+++ b/packages/millicast-sdk/src/Signaling.js
@@ -203,11 +203,11 @@ export default class Signaling extends EventEmitter {
    * Establish WebRTC connection with Millicast Server as Publisher role.
    * @param {String} sdp - The SDP information created by your offer.
    * @param {VideoCodec} [codec="h264"] - Codec for publish stream.
-   * @param {Boolean} [record=false] - Enable stream recording. **Only available in Tokens with recording enabled.**
+   * @param {Boolean} [record] - Enable stream recording. If record is not provided, use default Token configuration. **Only available in Tokens with recording enabled.**
    * @example const response = await millicastSignaling.publish(sdp, 'h264')
    * @return {Promise<String>} Promise object which represents the SDP command response.
    */
-  async publish (sdp, codec = VideoCodec.H264, record = false) {
+  async publish (sdp, codec = VideoCodec.H264, record = null) {
     logger.info(`Starting publishing to streamName: ${this.streamName}, codec: ${codec}`)
     logger.debug('Publishing local description: ', sdp)
 
@@ -225,8 +225,11 @@ export default class Signaling extends EventEmitter {
     const data = {
       name: this.streamName,
       sdp,
-      codec,
-      record
+      codec
+    }
+
+    if (record !== null) {
+      data.record = record
     }
 
     try {

--- a/packages/millicast-sdk/tests/features/OfferPublishingStream.feature
+++ b/packages/millicast-sdk/tests/features/OfferPublishingStream.feature
@@ -2,7 +2,7 @@ Feature: As a user I want to signal Millicast Server so I can offer publishing a
 
   Scenario: Offer a SDP with no previous connection and h264 codec
     Given a local sdp and no previous connection to server
-    When I offer my local sdp with h264 codec
+    When I offer my local sdp with h264 codec and recording option
     Then returns a filtered sdp to offer to remote peer
 
   Scenario: Offer a SDP with no previous connection and vp8 codec

--- a/packages/millicast-sdk/tests/features/step-definitions/OfferPublishingStream.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/OfferPublishingStream.steps.js
@@ -72,12 +72,12 @@ defineFeature(feature, test => {
       })
     })
 
-    when('I offer my local sdp with h264 codec', async () => {
+    when('I offer my local sdp with h264 codec and recording option', async () => {
       const signaling = new Signaling({
         streamName: streamName,
         url: publishWebSocketLocation
       })
-      response = await signaling.publish(localSdp, 'h264')
+      response = await signaling.publish(localSdp, 'h264', true)
     })
 
     then('returns a filtered sdp to offer to remote peer', async () => {

--- a/packages/millicast-sdk/tests/functional/utils/Media.js
+++ b/packages/millicast-sdk/tests/functional/utils/Media.js
@@ -7,10 +7,7 @@ class Media {
         echoCancellation: false,
         channelCount: { ideal: 2 }
       },
-      video: {
-        height: 1080,
-        width: 1920
-      }
+      video: true
     }
     /* Apply Options */
     if (options && !!options.constraints) { Object.assign(this.constraints, options.constraints) }


### PR DESCRIPTION
- If record option is not provided, use default token configuration. 
- Added behaviour in documentation.