### PR TITLE
Feature: Director refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ You will need a Millicast account and a valid publishing token that you can find
 ```javascript
 import { Director, Publish } from '@millicast/sdk'
 //Define callback for generate new tokens
-const tokenGenerator = () => Director.getPublisher('my-publishing-token', 'my-stream-name')
+const tokenGenerator = () => Director.getPublisher({
+    token: 'my-publishing-token', 
+    streamName: 'my-stream-name'
+  })
 
 //Create a new instance
 const millicastPublish = new Publish(streamName, tokenGenerator)
@@ -85,7 +88,10 @@ import { Director, View } from '@millicast/sdk'
 const video = document.getElementById('my-video')
 
 //Define callback for generate new token
-const tokenGenerator = () => Director.getSubscriber('my-stream-name', 'my-account-id')
+const tokenGenerator = () => Director.getSubscriber({
+    streamName: 'my-stream-name', 
+    streamAccountId: 'my-account-id'
+  })
 
 //Create a new instance
 const millicastView = new View(streamName, tokenGenerator, video)

--- a/packages/millicast-sdk/src/Director.js
+++ b/packages/millicast-sdk/src/Director.js
@@ -1,5 +1,4 @@
 import axios from 'axios'
-import jwtDecode from 'jwt-decode'
 import Logger from './Logger'
 
 const logger = Logger.get('Director')
@@ -15,7 +14,6 @@ let apiEndpoint = defaultApiEndpoint
  * @typedef {Object} MillicastDirectorResponse
  * @property {Array<String>} urls - WebSocket available URLs.
  * @property {String} jwt - Access token for signaling initialization.
- * @property {Object} jwtDecoded - Access token decoded.
  */
 
 /**
@@ -100,7 +98,7 @@ export default class Director {
     try {
       const { data } = await axios.post(url, payload, { headers })
       logger.debug('Getting publisher response: ', data)
-      return { ...data.data, jwtDecoded: jwtDecode(data.data.jwt).millicast }
+      return data.data
     } catch (e) {
       logger.error('Error while getting publisher connection path: ', e.response?.data)
       throw e
@@ -153,7 +151,7 @@ export default class Director {
     try {
       const { data } = await axios.post(url, payload, { headers })
       logger.debug('Getting subscriber response: ', data)
-      return { ...data.data, jwtDecoded: jwtDecode(data.data.jwt).millicast }
+      return data.data
     } catch (e) {
       logger.error('Error while getting subscriber connection path: ', e.response?.data)
       throw e

--- a/packages/millicast-sdk/src/Director.js
+++ b/packages/millicast-sdk/src/Director.js
@@ -19,6 +19,20 @@ let apiEndpoint = defaultApiEndpoint
  */
 
 /**
+ * @typedef {Object} DirectorPublisherOptions
+ * @property {String} token - Millicast Publishing Token.
+ * @property {String} streamName - Millicast Stream Name.
+ * @property {("WebRtc" | "Rtmp")} [streamType] - Millicast Stream Type.
+ */
+
+/**
+ * @typedef {Object} DirectorSubscriberOptions
+ * @property {String} streamName - Millicast publisher Stream Name.
+ * @property {String} streamAccountId - Millicast Account ID.
+ * @property {String} [subscriberToken] - Token to subscribe to secure streams. If you are subscribing to an unsecure stream, you can omit this param.
+ */
+
+/**
  * Simplify API calls to find the best server and region to publish and subscribe to.
  * For security reasosn all calls will return a [JWT](https://jwt.io) token forn authentication including the required
  * socket path to connect with.
@@ -49,18 +63,18 @@ export default class Director {
 
   /**
    * Get publisher connection data.
-   * @param {String} token - Millicast Publishing Token.
-   * @param {String} streamName - Millicast Stream Name.
-   * @param {("WebRtc" | "Rtmp")} [streamType] - Millicast Stream Type.
+   * @param {DirectorPublisherOptions | String} options - Millicast options. *Deprecated, use options parameter instead* Millicast Publishing Token.
+   * @param {String} [streamName] - *Deprecated, use options parameter instead* Millicast Stream Name.
+   * @param {("WebRtc" | "Rtmp")} [streamType] - *Deprecated, use options parameter instead* Millicast Stream Type.
    * @returns {Promise<MillicastDirectorResponse>} Promise object which represents the result of getting the publishing connection path.
-   * @example const response = await Director.getPublisher(token, streamName)
+   * @example const response = await Director.getPublisher(options)
    * @example
    * import { Publish, Director } from '@millicast/sdk'
    *
    * //Define getPublisher as callback for Publish
    * const streamName = "My Millicast Stream Name"
    * const token = "My Millicast publishing token"
-   * const tokenGenerator = () => Director.getPublisher(token, streamName)
+   * const tokenGenerator = () => Director.getPublisher({token, streamName})
    *
    * //Create a new instance
    * const millicastPublish = new Publish(streamName, tokenGenerator)
@@ -77,10 +91,11 @@ export default class Director {
    * await millicastPublish.connect(broadcastOptions)
    */
 
-  static async getPublisher (token, streamName, streamType = streamTypes.WEBRTC) {
-    logger.info('Getting publisher connection path for stream name: ', streamName)
-    const payload = { streamName, streamType }
-    const headers = { Authorization: `Bearer ${token}` }
+  static async getPublisher (options, streamName = null, streamType = streamTypes.WEBRTC) {
+    const optionsParsed = getPublisherOptions(options, streamName, streamType)
+    logger.info('Getting publisher connection path for stream name: ', optionsParsed.streamName)
+    const payload = { streamName: optionsParsed.streamName, streamType: optionsParsed.streamType }
+    const headers = { Authorization: `Bearer ${optionsParsed.token}` }
     const url = `${this.getEndpoint()}/api/director/publish`
     try {
       const { data } = await axios.post(url, payload, { headers })
@@ -94,20 +109,20 @@ export default class Director {
 
   /**
    * Get subscriber connection data.
-   * @param {String} streamName - Millicast publisher Stream Name.
-   * @param {String} streamAccountId - Millicast Account ID.
-   * @param {String} [subscriberToken] - Token to subscribe to secure streams. If you are subscribing to an unsecure stream, you can omit this param.
+   * @param {DirectorSubscriberOptions | String} options - Millicast options. *Deprecated, use options parameter instead* Millicast publisher Stream Name.
+   * @param {String} [streamAccountId] - *Deprecated, use options parameter instead* Millicast Account ID.
+   * @param {String} [subscriberToken] - *Deprecated, use options parameter instead* Token to subscribe to secure streams. If you are subscribing to an unsecure stream, you can omit this param.
    * @returns {Promise<MillicastDirectorResponse>} Promise object which represents the result of getting the subscribe connection data.
-   * @example const response = await Director.getSubscriber(streamName, streamAccountId)
+   * @example const response = await Director.getSubscriber(options)
    * @example
    * import { View, Director } from '@millicast/sdk'
    *
    * //Define getSubscriber as callback for Subscribe
    * const streamName = "My Millicast Stream Name"
    * const accountId = "Millicast Publisher account Id"
-   * const tokenGenerator = () => Director.getSubscriber(streamName, accountId)
+   * const tokenGenerator = () => Director.getSubscriber({streamName, accountId})
    * //... or for an secure stream
-   * const tokenGenerator = () => Director.getSubscriber(streamName, accountId, '176949b9e57de248d37edcff1689a84a047370ddc3f0dd960939ad1021e0b744')
+   * const tokenGenerator = () => Director.getSubscriber({streamName, accountId, subscriberToken: '176949b9e57de248d37edcff1689a84a047370ddc3f0dd960939ad1021e0b744'})
    *
    * //Create a new instance
    * const millicastView = new View(streamName, tokenGenerator)
@@ -125,12 +140,14 @@ export default class Director {
    * await millicastView.connect(options)
    */
 
-  static async getSubscriber (streamName, streamAccountId, subscriberToken = null) {
-    logger.info(`Getting subscriber connection data for stream name: ${streamName} and account id: ${streamAccountId}`)
-    const payload = { streamAccountId, streamName }
+  static async getSubscriber (options, streamAccountId = null, subscriberToken = null) {
+    const optionsParsed = getSubscriberOptions(options, streamAccountId, subscriberToken)
+    logger.info(`Getting subscriber connection data for stream name: ${optionsParsed.streamName} and account id: ${optionsParsed.streamAccountId}`)
+
+    const payload = { streamAccountId: optionsParsed.streamAccountId, streamName: optionsParsed.streamName }
     let headers = {}
-    if (subscriberToken) {
-      headers = { Authorization: `Bearer ${subscriberToken}` }
+    if (optionsParsed.subscriberToken) {
+      headers = { Authorization: `Bearer ${optionsParsed.subscriberToken}` }
     }
     const url = `${this.getEndpoint()}/api/director/subscribe`
     try {
@@ -142,4 +159,28 @@ export default class Director {
       throw e
     }
   }
+}
+
+const getPublisherOptions = (options, legacyStreamName, legacyStreamType) => {
+  let parsedOptions = (typeof options === 'object') ? options : {}
+  if (Object.keys(parsedOptions).length === 0) {
+    parsedOptions = {
+      token: options,
+      streamName: legacyStreamName,
+      streamType: legacyStreamType
+    }
+  }
+  return parsedOptions
+}
+
+const getSubscriberOptions = (options, legacyStreamAccountId, legacySubscriberToken) => {
+  let parsedOptions = (typeof options === 'object') ? options : {}
+  if (Object.keys(parsedOptions).length === 0) {
+    parsedOptions = {
+      streamName: options,
+      streamAccountId: legacyStreamAccountId,
+      subscriberToken: legacySubscriberToken
+    }
+  }
+  return parsedOptions
 }

--- a/packages/millicast-sdk/src/Director.js
+++ b/packages/millicast-sdk/src/Director.js
@@ -63,7 +63,7 @@ export default class Director {
 
   /**
    * Get publisher connection data.
-   * @param {DirectorPublisherOptions | String} options - Millicast options. *Deprecated, use options parameter instead* Millicast Publishing Token.
+   * @param {DirectorPublisherOptions | String} options - Millicast options or *Deprecated Millicast Publishing Token.*
    * @param {String} [streamName] - *Deprecated, use options parameter instead* Millicast Stream Name.
    * @param {("WebRtc" | "Rtmp")} [streamType] - *Deprecated, use options parameter instead* Millicast Stream Type.
    * @returns {Promise<MillicastDirectorResponse>} Promise object which represents the result of getting the publishing connection path.
@@ -109,7 +109,7 @@ export default class Director {
 
   /**
    * Get subscriber connection data.
-   * @param {DirectorSubscriberOptions | String} options - Millicast options. *Deprecated, use options parameter instead* Millicast publisher Stream Name.
+   * @param {DirectorSubscriberOptions | String} options - Millicast options or *Deprecated Millicast publisher Stream Name.*
    * @param {String} [streamAccountId] - *Deprecated, use options parameter instead* Millicast Account ID.
    * @param {String} [subscriberToken] - *Deprecated, use options parameter instead* Token to subscribe to secure streams. If you are subscribing to an unsecure stream, you can omit this param.
    * @returns {Promise<MillicastDirectorResponse>} Promise object which represents the result of getting the subscribe connection data.

--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -1,3 +1,4 @@
+import jwtDecode from 'jwt-decode'
 import reemit from 're-emitter'
 import Logger from './Logger'
 import BaseWebRTC from './utils/BaseWebRTC'
@@ -102,6 +103,11 @@ export default class Publish extends BaseWebRTC {
     if (!publisherData) {
       logger.error('Error while broadcasting. Publisher data required')
       throw new Error('Publisher data required')
+    }
+    const recordingAvailable = jwtDecode(publisherData.jwt).millicast.record
+    if (this.options.record && !recordingAvailable) {
+      logger.error('Error while broadcasting. Record option detected but recording is not available')
+      throw new Error('Record option detected but recording is not available')
     }
     this.signaling = new Signaling({
       streamName: this.streamName,

--- a/packages/millicast-sdk/tests/features/GetPublisherConnectionPath.feature
+++ b/packages/millicast-sdk/tests/features/GetPublisherConnectionPath.feature
@@ -19,3 +19,8 @@ Feature: As a user I want to publish to a Millicast Stream so I can get a connec
     Given I have a valid token and an existing stream name
     When I request a connection path to Director API
     Then I get the publish connection path
+
+  Scenario: Publish with an existing stream name, valid token and options as object
+    Given I have a valid token and an existing stream name
+    When I request a connection path to Director API using options object
+    Then I get the publish connection path

--- a/packages/millicast-sdk/tests/features/GetSubscriberConnectionPath.feature
+++ b/packages/millicast-sdk/tests/features/GetSubscriberConnectionPath.feature
@@ -19,3 +19,8 @@ Feature: As a user I want to subscribe to a Millicast Stream so I can get a conn
     Given I have an existing stream name, accountId and no token
     When I request a connection path to Director API
     Then I get the subscriber connection path
+
+  Scenario: Subscribe to an existing unrestricted stream, valid accountId, no token and options as object
+    Given I have an existing stream name, accountId and no token
+    When I request a connection path to Director API using options object
+    Then I get the subscriber connection path

--- a/packages/millicast-sdk/tests/features/Publish.feature
+++ b/packages/millicast-sdk/tests/features/Publish.feature
@@ -64,3 +64,8 @@ Feature: As a user I want to publish a stream without managing connections
     Given an instance of Publish with invalid token generator
     When I broadcast a stream
     Then throws token generator error
+
+  Scenario: Broadcast to stream with record option but no record available from token
+    Given an instance of Publish with valid token generator with no recording available
+    When I broadcast a stream
+    Then throws an error

--- a/packages/millicast-sdk/tests/features/step-definitions/GetPublisherConnectionPath.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/GetPublisherConnectionPath.steps.js
@@ -148,4 +148,38 @@ defineFeature(feature, test => {
       expect(response).toEqual(expect.objectContaining(mockedResponse.data.data))
     })
   })
+
+  test('Publish with an existing stream name, valid token and options as object', ({ given, when, then }) => {
+    let token
+    let streamName
+    let response
+    const mockedResponse = {
+      data: {
+        status: 'success',
+        data: {
+          subscribeRequiresAuth: false,
+          wsUrl: 'wss://live-west.millicast.com/ws/v2/pub/12345',
+          urls: [
+            'wss://live-west.millicast.com/ws/v2/pub/12345'
+          ],
+          jwt: dummyToken,
+          streamAccountId: 'Existing_accountId'
+        }
+      }
+    }
+    given('I have a valid token and an existing stream name', async () => {
+      token = 'Valid_token'
+      streamName = 'Existing_stream_name'
+    })
+
+    when('I request a connection path to Director API using options object', async () => {
+      axios.post.mockResolvedValue(mockedResponse)
+      response = await Director.getPublisher({ token, streamName })
+    })
+
+    then('I get the publish connection path', async () => {
+      expect(response).toBeDefined()
+      expect(response).toEqual(expect.objectContaining(mockedResponse.data.data))
+    })
+  })
 })

--- a/packages/millicast-sdk/tests/features/step-definitions/GetSubscriberConnectionPath.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/GetSubscriberConnectionPath.steps.js
@@ -146,4 +146,37 @@ defineFeature(feature, test => {
       expect(response).toEqual(expect.objectContaining(mockedResponse.data.data))
     })
   })
+
+  test('Subscribe to an existing unrestricted stream, valid accountId, no token and options as object', ({ given, when, then }) => {
+    let accountId
+    let streamName
+    let response
+    const mockedResponse = {
+      data: {
+        status: 'success',
+        data: {
+          wsUrl: 'wss://live-west.millicast.com/ws/v2/sub/12345',
+          urls: [
+            'wss://live-west.millicast.com/ws/v2/sub/12345'
+          ],
+          jwt: dummyToken,
+          streamAccountId: 'Existing_accountId'
+        }
+      }
+    }
+    given('I have an existing stream name, accountId and no token', async () => {
+      accountId = 'Existing_accountId'
+      streamName = 'Existing_stream_name'
+    })
+
+    when('I request a connection path to Director API using options object', async () => {
+      axios.post.mockResolvedValue(mockedResponse)
+      response = await Director.getSubscriber({ streamName, streamAccountId: accountId })
+    })
+
+    then('I get the subscriber connection path', async () => {
+      expect(response).toBeDefined()
+      expect(response).toEqual(expect.objectContaining(mockedResponse.data.data))
+    })
+  })
 })

--- a/packages/millicast-sdk/tests/features/step-definitions/PeerStats.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/PeerStats.steps.js
@@ -17,7 +17,7 @@ const mockTokenGenerator = jest.fn(() => {
     urls: [
       'ws://localhost:8080'
     ],
-    jwt: 'this-is-a-jwt-dummy-token'
+    jwt: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJtaWxsaWNhc3QiOnt9fQ.IqT-PLLz-X7Wn7BNo-x4pFApAbMT9mmnlupR8eD9q4U'
   }
 })
 

--- a/packages/millicast-sdk/tests/features/step-definitions/Publish.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/Publish.steps.js
@@ -15,7 +15,7 @@ const mockTokenGenerator = jest.fn(() => {
     urls: [
       'ws://localhost:8080'
     ],
-    jwt: 'this-is-a-jwt-dummy-token'
+    jwt: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJtaWxsaWNhc3QiOnt9fQ.IqT-PLLz-X7Wn7BNo-x4pFApAbMT9mmnlupR8eD9q4U'
   }
 })
 
@@ -253,6 +253,24 @@ defineFeature(feature, test => {
     then('throws token generator error', async () => {
       expectError.rejects.toThrow(Error)
       expectError.rejects.toThrow('Error getting token')
+    })
+  })
+
+  test('Broadcast to stream with record option but no record available from token', ({ given, when, then }) => {
+    let publisher
+    let expectError
+
+    given('an instance of Publish with valid token generator with no recording available', async () => {
+      publisher = new Publish('streamName', mockTokenGenerator)
+    })
+
+    when('I broadcast a stream', async () => {
+      expectError = expect(() => publisher.connect({ mediaStream, record: true }))
+    })
+
+    then('throws an error', async () => {
+      expectError.rejects.toThrow(Error)
+      expectError.rejects.toThrow('Record option detected but recording is not available')
     })
   })
 })

--- a/packages/millicast-sdk/tests/features/step-definitions/PublisherReconnect.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/PublisherReconnect.steps.js
@@ -15,7 +15,7 @@ const mockTokenGenerator = jest.fn(() => {
     urls: [
       'ws://localhost:8080'
     ],
-    jwt: 'this-is-a-jwt-dummy-token'
+    jwt: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJtaWxsaWNhc3QiOnt9fQ.IqT-PLLz-X7Wn7BNo-x4pFApAbMT9mmnlupR8eD9q4U'
   }
 })
 

--- a/packages/millicast-sdk/tests/functional/PublishTest.js
+++ b/packages/millicast-sdk/tests/functional/PublishTest.js
@@ -3,7 +3,7 @@ const accountId = window.accountId
 const streamName = window.streamName
 const token = window.token
 
-const tokenGenerator = () => millicast.Director.getPublisher(token, streamName)
+const tokenGenerator = () => millicast.Director.getPublisher({ token, streamName })
 
 class MillicastPublishTest {
   constructor () {

--- a/packages/millicast-sdk/tests/functional/ViewTest.js
+++ b/packages/millicast-sdk/tests/functional/ViewTest.js
@@ -11,7 +11,7 @@ class MillicastViewTest {
     this.playing = false
     this.disableVideo = false
     this.disableAudio = false
-    const tokenGenerator = () => millicast.Director.getSubscriber(this.streamName, this.streamAccountId)
+    const tokenGenerator = () => millicast.Director.getSubscriber({ streamName: this.streamName, streamAccountId: this.streamAccountId })
     this.millicastView = new millicast.View(this.streamName, tokenGenerator)
     this.tracks = []
   }


### PR DESCRIPTION
- #81:
  - Moved JWT decoding to Publisher.
  - Added recording availability validation from token using decoded JWT.
- #83:
  - Changed `.getPublisher` and `.getSubscriber` params, now receives an object param with all the available options
  - It's backward compatible, you can use the older params as always.
  - Changed documentation with examples to option param.