### PR TITLE
Release v0.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ You will need a Millicast account and a valid publishing token that you can find
 ```javascript
 import { Director, Publish } from '@millicast/sdk'
 //Define callback for generate new tokens
-const tokenGenerator = () => Director.getPublisher('my-publishing-token', 'my-stream-name')
+const tokenGenerator = () => Director.getPublisher({
+    token: 'my-publishing-token', 
+    streamName: 'my-stream-name'
+  })
 
 //Create a new instance
 const millicastPublish = new Publish(streamName, tokenGenerator)
@@ -85,7 +88,10 @@ import { Director, View } from '@millicast/sdk'
 const video = document.getElementById('my-video')
 
 //Define callback for generate new token
-const tokenGenerator = () => Director.getSubscriber('my-stream-name', 'my-account-id')
+const tokenGenerator = () => Director.getSubscriber({
+    streamName: 'my-stream-name', 
+    streamAccountId: 'my-account-id'
+  })
 
 //Create a new instance
 const millicastView = new View(streamName, tokenGenerator, video)

--- a/packages/millicast-sdk/src/PeerConnection.js
+++ b/packages/millicast-sdk/src/PeerConnection.js
@@ -212,7 +212,7 @@ export default class PeerConnection extends EventEmitter {
     }
 
     logger.info('Updating bitrate to value: ', bitrate)
-    this.peer = await this.getRTCPeer()
+    this.sessionDescription = await this.peer.createOffer()
     await this.peer.setLocalDescription(this.sessionDescription)
     const sdp = this.updateBandwidthRestriction(this.peer.remoteDescription.sdp, bitrate)
     await this.setRTCRemoteSDP(sdp)

--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -1,3 +1,4 @@
+import jwtDecode from 'jwt-decode'
 import reemit from 're-emitter'
 import Logger from './Logger'
 import BaseWebRTC from './utils/BaseWebRTC'
@@ -102,6 +103,11 @@ export default class Publish extends BaseWebRTC {
     if (!publisherData) {
       logger.error('Error while broadcasting. Publisher data required')
       throw new Error('Publisher data required')
+    }
+    const recordingAvailable = jwtDecode(publisherData.jwt).millicast.record
+    if (this.options.record && !recordingAvailable) {
+      logger.error('Error while broadcasting. Record option detected but recording is not available')
+      throw new Error('Record option detected but recording is not available')
     }
     this.signaling = new Signaling({
       streamName: this.streamName,

--- a/packages/millicast-sdk/src/utils/BaseWebRTC.js
+++ b/packages/millicast-sdk/src/utils/BaseWebRTC.js
@@ -49,6 +49,14 @@ export default class BaseWebRTC extends EventEmitter {
   }
 
   /**
+  * Get current RTC peer connection.
+  * @returns {RTCPeerConnection} Object which represents the RTCPeerConnection.
+  */
+  getRTCPeerConnection () {
+    return this.webRTCPeer ? this.webRTCPeer.getRTCPeer() : null
+  }
+
+  /**
    * Stops connection.
    */
   stop () {

--- a/packages/millicast-sdk/tests/features/BaseWebRTC.feature
+++ b/packages/millicast-sdk/tests/features/BaseWebRTC.feature
@@ -1,0 +1,11 @@
+Feature: As a user I want to get the peer so I can use it
+
+  Scenario: Get existing RTC peer
+    Given I have a BaseWebRTC instanced and existing peer
+    When I want to get the peer
+    Then returns the peer
+
+  Scenario: Get no existing RTC peer
+    Given I have a BaseWebRTC instanced and no existing peer
+    When I want to get the peer
+    Then returns null

--- a/packages/millicast-sdk/tests/features/GetPublisherConnectionPath.feature
+++ b/packages/millicast-sdk/tests/features/GetPublisherConnectionPath.feature
@@ -19,3 +19,8 @@ Feature: As a user I want to publish to a Millicast Stream so I can get a connec
     Given I have a valid token and an existing stream name
     When I request a connection path to Director API
     Then I get the publish connection path
+
+  Scenario: Publish with an existing stream name, valid token and options as object
+    Given I have a valid token and an existing stream name
+    When I request a connection path to Director API using options object
+    Then I get the publish connection path

--- a/packages/millicast-sdk/tests/features/GetSubscriberConnectionPath.feature
+++ b/packages/millicast-sdk/tests/features/GetSubscriberConnectionPath.feature
@@ -19,3 +19,8 @@ Feature: As a user I want to subscribe to a Millicast Stream so I can get a conn
     Given I have an existing stream name, accountId and no token
     When I request a connection path to Director API
     Then I get the subscriber connection path
+
+  Scenario: Subscribe to an existing unrestricted stream, valid accountId, no token and options as object
+    Given I have an existing stream name, accountId and no token
+    When I request a connection path to Director API using options object
+    Then I get the subscriber connection path

--- a/packages/millicast-sdk/tests/features/Publish.feature
+++ b/packages/millicast-sdk/tests/features/Publish.feature
@@ -64,3 +64,8 @@ Feature: As a user I want to publish a stream without managing connections
     Given an instance of Publish with invalid token generator
     When I broadcast a stream
     Then throws token generator error
+
+  Scenario: Broadcast to stream with record option but no record available from token
+    Given an instance of Publish with valid token generator with no recording available
+    When I broadcast a stream
+    Then throws an error

--- a/packages/millicast-sdk/tests/features/step-definitions/BaseWebRTC.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/BaseWebRTC.steps.js
@@ -1,0 +1,54 @@
+import { loadFeature, defineFeature } from 'jest-cucumber'
+import BaseWebRTC from '../../../src/utils/BaseWebRTC'
+import PeerConnection from '../../../src/PeerConnection'
+import { defaultConfig } from './__mocks__/MockRTCPeerConnection'
+import './__mocks__/MockMediaStream'
+const feature = loadFeature('../BaseWebRTC.feature', { loadRelativePath: true, errors: true })
+
+defineFeature(feature, test => {
+  beforeEach(() => {
+    jest.spyOn(PeerConnection.prototype, 'getRTCIceServers').mockReturnValue([])
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+  })
+
+  test('Get existing RTC peer', ({ given, when, then }) => {
+    let baseWebRTC = null
+    let peer = null
+
+    given('I have a BaseWebRTC instanced and existing peer', async () => {
+      jest.spyOn(PeerConnection.prototype, 'getRTCIceServers').mockReturnValue([])
+      baseWebRTC = new BaseWebRTC('test', () => {}, null, false)
+      await baseWebRTC.webRTCPeer.createRTCPeer()
+    })
+
+    when('I want to get the peer', () => {
+      peer = baseWebRTC.getRTCPeerConnection()
+    })
+
+    then('returns the peer', async () => {
+      expect(peer.getConfiguration()).toMatchObject({ ...defaultConfig, bundlePolicy: 'balanced' })
+    })
+  })
+
+  test('Get no existing RTC peer', ({ given, when, then }) => {
+    let baseWebRTC = null
+    let peer = null
+
+    given('I have a BaseWebRTC instanced and no existing peer', async () => {
+      jest.spyOn(PeerConnection.prototype, 'getRTCIceServers').mockReturnValue([])
+      baseWebRTC = new BaseWebRTC('test', () => {}, null, false)
+      baseWebRTC.webRTCPeer = null
+    })
+
+    when('I want to get the peer', () => {
+      peer = baseWebRTC.getRTCPeerConnection()
+    })
+
+    then('returns null', async () => {
+      expect(peer).toBeNull()
+    })
+  })
+})

--- a/packages/millicast-sdk/tests/features/step-definitions/GetPublisherConnectionPath.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/GetPublisherConnectionPath.steps.js
@@ -148,4 +148,38 @@ defineFeature(feature, test => {
       expect(response).toEqual(expect.objectContaining(mockedResponse.data.data))
     })
   })
+
+  test('Publish with an existing stream name, valid token and options as object', ({ given, when, then }) => {
+    let token
+    let streamName
+    let response
+    const mockedResponse = {
+      data: {
+        status: 'success',
+        data: {
+          subscribeRequiresAuth: false,
+          wsUrl: 'wss://live-west.millicast.com/ws/v2/pub/12345',
+          urls: [
+            'wss://live-west.millicast.com/ws/v2/pub/12345'
+          ],
+          jwt: dummyToken,
+          streamAccountId: 'Existing_accountId'
+        }
+      }
+    }
+    given('I have a valid token and an existing stream name', async () => {
+      token = 'Valid_token'
+      streamName = 'Existing_stream_name'
+    })
+
+    when('I request a connection path to Director API using options object', async () => {
+      axios.post.mockResolvedValue(mockedResponse)
+      response = await Director.getPublisher({ token, streamName })
+    })
+
+    then('I get the publish connection path', async () => {
+      expect(response).toBeDefined()
+      expect(response).toEqual(expect.objectContaining(mockedResponse.data.data))
+    })
+  })
 })

--- a/packages/millicast-sdk/tests/features/step-definitions/GetSubscriberConnectionPath.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/GetSubscriberConnectionPath.steps.js
@@ -146,4 +146,37 @@ defineFeature(feature, test => {
       expect(response).toEqual(expect.objectContaining(mockedResponse.data.data))
     })
   })
+
+  test('Subscribe to an existing unrestricted stream, valid accountId, no token and options as object', ({ given, when, then }) => {
+    let accountId
+    let streamName
+    let response
+    const mockedResponse = {
+      data: {
+        status: 'success',
+        data: {
+          wsUrl: 'wss://live-west.millicast.com/ws/v2/sub/12345',
+          urls: [
+            'wss://live-west.millicast.com/ws/v2/sub/12345'
+          ],
+          jwt: dummyToken,
+          streamAccountId: 'Existing_accountId'
+        }
+      }
+    }
+    given('I have an existing stream name, accountId and no token', async () => {
+      accountId = 'Existing_accountId'
+      streamName = 'Existing_stream_name'
+    })
+
+    when('I request a connection path to Director API using options object', async () => {
+      axios.post.mockResolvedValue(mockedResponse)
+      response = await Director.getSubscriber({ streamName, streamAccountId: accountId })
+    })
+
+    then('I get the subscriber connection path', async () => {
+      expect(response).toBeDefined()
+      expect(response).toEqual(expect.objectContaining(mockedResponse.data.data))
+    })
+  })
 })

--- a/packages/millicast-sdk/tests/features/step-definitions/PeerStats.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/PeerStats.steps.js
@@ -17,7 +17,7 @@ const mockTokenGenerator = jest.fn(() => {
     urls: [
       'ws://localhost:8080'
     ],
-    jwt: 'this-is-a-jwt-dummy-token'
+    jwt: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJtaWxsaWNhc3QiOnt9fQ.IqT-PLLz-X7Wn7BNo-x4pFApAbMT9mmnlupR8eD9q4U'
   }
 })
 

--- a/packages/millicast-sdk/tests/features/step-definitions/Publish.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/Publish.steps.js
@@ -15,7 +15,7 @@ const mockTokenGenerator = jest.fn(() => {
     urls: [
       'ws://localhost:8080'
     ],
-    jwt: 'this-is-a-jwt-dummy-token'
+    jwt: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJtaWxsaWNhc3QiOnt9fQ.IqT-PLLz-X7Wn7BNo-x4pFApAbMT9mmnlupR8eD9q4U'
   }
 })
 
@@ -253,6 +253,24 @@ defineFeature(feature, test => {
     then('throws token generator error', async () => {
       expectError.rejects.toThrow(Error)
       expectError.rejects.toThrow('Error getting token')
+    })
+  })
+
+  test('Broadcast to stream with record option but no record available from token', ({ given, when, then }) => {
+    let publisher
+    let expectError
+
+    given('an instance of Publish with valid token generator with no recording available', async () => {
+      publisher = new Publish('streamName', mockTokenGenerator)
+    })
+
+    when('I broadcast a stream', async () => {
+      expectError = expect(() => publisher.connect({ mediaStream, record: true }))
+    })
+
+    then('throws an error', async () => {
+      expectError.rejects.toThrow(Error)
+      expectError.rejects.toThrow('Record option detected but recording is not available')
     })
   })
 })

--- a/packages/millicast-sdk/tests/features/step-definitions/PublisherReconnect.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/PublisherReconnect.steps.js
@@ -15,7 +15,7 @@ const mockTokenGenerator = jest.fn(() => {
     urls: [
       'ws://localhost:8080'
     ],
-    jwt: 'this-is-a-jwt-dummy-token'
+    jwt: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJtaWxsaWNhc3QiOnt9fQ.IqT-PLLz-X7Wn7BNo-x4pFApAbMT9mmnlupR8eD9q4U'
   }
 })
 

--- a/packages/millicast-sdk/tests/functional/PublishTest.js
+++ b/packages/millicast-sdk/tests/functional/PublishTest.js
@@ -3,7 +3,7 @@ const accountId = window.accountId
 const streamName = window.streamName
 const token = window.token
 
-const tokenGenerator = () => millicast.Director.getPublisher(token, streamName)
+const tokenGenerator = () => millicast.Director.getPublisher({ token, streamName })
 
 class MillicastPublishTest {
   constructor () {

--- a/packages/millicast-sdk/tests/functional/ViewTest.js
+++ b/packages/millicast-sdk/tests/functional/ViewTest.js
@@ -11,7 +11,7 @@ class MillicastViewTest {
     this.playing = false
     this.disableVideo = false
     this.disableAudio = false
-    const tokenGenerator = () => millicast.Director.getSubscriber(this.streamName, this.streamAccountId)
+    const tokenGenerator = () => millicast.Director.getSubscriber({ streamName: this.streamName, streamAccountId: this.streamAccountId })
     this.millicastView = new millicast.View(this.streamName, tokenGenerator)
     this.tracks = []
   }


### PR DESCRIPTION
# Changelog

### Added 
* `.getRTCPeerConnection()` to BaseWebRTC.

### Changed
* Closes #81
  * Changes `.getPublisher` and `.getSubscriber` params, now receives an object param with all the available options.
  * It's backward compatible, you can use the older params as always.
  * Changes documentation with examples to option param.
* Closes #83
  * Removes `jwtDecoded` from Director response. 
  * Moves JWT decoding to Publisher.
  * Adds recording availability validation from token using decoded JWT.

### Fixed
* Fixes `.updateBitrate()` in Firefox browser.