### PR TITLE
Feature: Configurable domains

### DIFF
--- a/packages/millicast-sdk/src/PeerConnection.js
+++ b/packages/millicast-sdk/src/PeerConnection.js
@@ -15,6 +15,9 @@ export const webRTCEvents = {
   connectionStateChange: 'connectionStateChange'
 }
 
+export const defaultTurnServerLocation = 'https://turn.millicast.com/webrtc/_turn'
+let turnServerLocation = defaultTurnServerLocation
+
 const localSDPOptions = {
   stereo: false,
   mediaStream: null,
@@ -38,6 +41,25 @@ export default class PeerConnection extends EventEmitter {
     this.sessionDescription = null
     this.peer = null
     this.peerConnectionStats = null
+  }
+
+  /**
+   * Set TURN server location.
+   *
+   * @param {String} url - New TURN location
+   */
+  static setTurnServerLocation (url) {
+    turnServerLocation = url
+  }
+
+  /**
+   * Get current TURN location.
+   *
+   * By default, https://turn.millicast.com/webrtc/_turn is the current TURN location.
+   * @returns {String} TURN url
+   */
+  static getTurnServerLocation () {
+    return turnServerLocation
   }
 
   /**
@@ -91,10 +113,11 @@ export default class PeerConnection extends EventEmitter {
 
   /**
    * Get Ice servers from a Millicast signaling server.
-   * @param {String} location - URL of signaling server where Ice servers will be obtained.
+   * @param {String} location - *Deprecated, use .setTurnServerLocation() method instead* URL of signaling server where Ice servers will be obtained.
    * @returns {Promise<Array<RTCIceServer>>} Promise object which represents a list of Ice servers.
    */
-  async getRTCIceServers (location = 'https://turn.millicast.com/webrtc/_turn') {
+  async getRTCIceServers (location) {
+    location = location ?? turnServerLocation
     logger.info('Getting RTC ICE servers')
     logger.debug('RTC ICE servers request location: ', location)
 

--- a/packages/millicast-sdk/src/StreamEvents.js
+++ b/packages/millicast-sdk/src/StreamEvents.js
@@ -8,6 +8,9 @@ const logger = Logger.get('StreamEvents')
 const messageType = { REQUEST: 1, RESPONSE: 3 }
 let invocationId = 0
 
+export const defaultEventsLocation = 'wss://streamevents.millicast.com/ws'
+let eventsLocation = defaultEventsLocation
+
 const errorMsg = 'You need to initialize stream event with StreamEvents.init()'
 
 /**
@@ -40,10 +43,29 @@ export default class StreamEvents {
    */
   static async init () {
     const instance = new StreamEvents()
-    instance.eventSubscriber = new EventSubscriber()
+    instance.eventSubscriber = new EventSubscriber(this.getEventsLocation())
     await instance.eventSubscriber.initializeHandshake()
 
     return instance
+  }
+
+  /**
+   * Set Websocket Stream Events location.
+   *
+   * @param {String} url - New Stream Events location
+  */
+  static setEventsLocation (url) {
+    eventsLocation = url
+  }
+
+  /**
+   * Get current Websocket Stream Events location.
+   *
+   * By default, wss://streamevents.millicast.com/ws is the location.
+   * @returns {String} Stream Events location
+  */
+  static getEventsLocation () {
+    return eventsLocation
   }
 
   /**

--- a/packages/millicast-sdk/src/utils/EventSubscriber.js
+++ b/packages/millicast-sdk/src/utils/EventSubscriber.js
@@ -2,13 +2,13 @@ import Logger from '../Logger'
 import EventEmitter from 'events'
 
 const logger = Logger.get('EventSubscriber')
-export const eventsLocation = 'wss://streamevents.millicast.com/ws'
 export const recordSeparator = '\x1E'
 
 export default class EventSubscriber extends EventEmitter {
-  constructor () {
+  constructor (eventsLocation) {
     super()
     this.webSocket = null
+    this.eventsLocation = eventsLocation
   }
 
   /**
@@ -41,7 +41,7 @@ export default class EventSubscriber extends EventEmitter {
     if (this.webSocket?.readyState !== WebSocket.CONNECTING && this.webSocket?.readyState !== WebSocket.OPEN) {
       return new Promise((resolve, reject) => {
         logger.info('Starting events WebSocket handshake.')
-        this.webSocket = new WebSocket(eventsLocation)
+        this.webSocket = new WebSocket(this.eventsLocation)
         this.webSocket.onopen = () => {
           logger.info('Connection established with events WebSocket.')
           const handshakeRequest = {

--- a/packages/millicast-sdk/tests/features/GetIceServer.feature
+++ b/packages/millicast-sdk/tests/features/GetIceServer.feature
@@ -24,3 +24,8 @@ Feature: As a user I want to get ICE server so I can configure a peer connection
     Given I do not have an ICE server location
     When I want to get the RTC Ice Servers and server responds with 500 error
     Then returns empty ICE Servers
+
+  Scenario: Get RTC Ice servers with custom location set in static method
+    Given I have an ICE server location
+    When I set the TURN server location and I want to get the RTC Ice Servers
+    Then returns the ICE Servers

--- a/packages/millicast-sdk/tests/features/GetPublisherConnectionPath.feature
+++ b/packages/millicast-sdk/tests/features/GetPublisherConnectionPath.feature
@@ -24,3 +24,8 @@ Feature: As a user I want to publish to a Millicast Stream so I can get a connec
     Given I have a valid token and an existing stream name
     When I request a connection path to Director API using options object
     Then I get the publish connection path
+
+  Scenario: Publish to an existing stream name, valid token and custom live websocket domain
+    Given I have a valid token and an existing stream name
+    When I set a custom live websocket domain and I request a connection path to Director API
+    Then I get the publish connection path

--- a/packages/millicast-sdk/tests/features/GetSubscriberConnectionPath.feature
+++ b/packages/millicast-sdk/tests/features/GetSubscriberConnectionPath.feature
@@ -24,3 +24,8 @@ Feature: As a user I want to subscribe to a Millicast Stream so I can get a conn
     Given I have an existing stream name, accountId and no token
     When I request a connection path to Director API using options object
     Then I get the subscriber connection path
+
+  Scenario: Subscribe to an existing stream, valid accountId, no token and custom live websocket domain
+    Given I have an existing stream name, accountId and no token
+    When I set a custom live websocket domain and I request a connection path to Director API
+    Then I get the subscriber connection path

--- a/packages/millicast-sdk/tests/features/step-definitions/GetPublisherConnectionPath.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/GetPublisherConnectionPath.steps.js
@@ -7,6 +7,10 @@ jest.mock('axios')
 const dummyToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJtaWxsaWNhc3QiOnt9fQ.IqT-PLLz-X7Wn7BNo-x4pFApAbMT9mmnlupR8eD9q4U'
 
 defineFeature(feature, test => {
+  beforeEach(() => {
+    Director.setLiveDomain('')
+  })
+
   test('Publish with an existing stream name and valid token', ({ given, when, then }) => {
     let token
     let streamName
@@ -175,6 +179,41 @@ defineFeature(feature, test => {
     when('I request a connection path to Director API using options object', async () => {
       axios.post.mockResolvedValue(mockedResponse)
       response = await Director.getPublisher({ token, streamName })
+    })
+
+    then('I get the publish connection path', async () => {
+      expect(response).toBeDefined()
+      expect(response).toEqual(expect.objectContaining(mockedResponse.data.data))
+    })
+  })
+
+  test('Publish to an existing stream name, valid token and custom live websocket domain', ({ given, when, then }) => {
+    let token
+    let streamName
+    let response
+    const mockedResponse = {
+      data: {
+        status: 'success',
+        data: {
+          subscribeRequiresAuth: false,
+          wsUrl: 'wss://live-west.millicast.com/ws/v2/pub/12345',
+          urls: [
+            'wss://test.com/ws/v2/pub/12345'
+          ],
+          jwt: dummyToken,
+          streamAccountId: 'Existing_accountId'
+        }
+      }
+    }
+    given('I have a valid token and an existing stream name', async () => {
+      token = 'Valid_token'
+      streamName = 'Existing_stream_name'
+    })
+
+    when('I set a custom live websocket domain and I request a connection path to Director API', async () => {
+      Director.setLiveDomain('test.com')
+      axios.post.mockResolvedValue(mockedResponse)
+      response = await Director.getPublisher(token, streamName)
     })
 
     then('I get the publish connection path', async () => {

--- a/packages/millicast-sdk/tests/features/step-definitions/GetSubscriberConnectionPath.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/GetSubscriberConnectionPath.steps.js
@@ -7,6 +7,10 @@ jest.mock('axios')
 const dummyToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJtaWxsaWNhc3QiOnt9fQ.IqT-PLLz-X7Wn7BNo-x4pFApAbMT9mmnlupR8eD9q4U'
 
 defineFeature(feature, test => {
+  beforeEach(() => {
+    Director.setLiveDomain('')
+  })
+
   test('Subscribe to an existing unrestricted stream, valid accountId and no token', ({ given, when, then }) => {
     let accountId
     let streamName
@@ -172,6 +176,40 @@ defineFeature(feature, test => {
     when('I request a connection path to Director API using options object', async () => {
       axios.post.mockResolvedValue(mockedResponse)
       response = await Director.getSubscriber({ streamName, streamAccountId: accountId })
+    })
+
+    then('I get the subscriber connection path', async () => {
+      expect(response).toBeDefined()
+      expect(response).toEqual(expect.objectContaining(mockedResponse.data.data))
+    })
+  })
+
+  test('Subscribe to an existing stream, valid accountId, no token and custom live websocket domain', ({ given, when, then }) => {
+    let accountId
+    let streamName
+    let response
+    const mockedResponse = {
+      data: {
+        status: 'success',
+        data: {
+          wsUrl: 'wss://live-west.millicast.com/ws/v2/sub/12345',
+          urls: [
+            'wss://test.com/ws/v2/sub/12345'
+          ],
+          jwt: dummyToken,
+          streamAccountId: 'Existing_accountId'
+        }
+      }
+    }
+    given('I have an existing stream name, accountId and no token', async () => {
+      accountId = 'Existing_accountId'
+      streamName = 'Existing_stream_name'
+    })
+
+    when('I set a custom live websocket domain and I request a connection path to Director API', async () => {
+      Director.setLiveDomain('test.com')
+      axios.post.mockResolvedValue(mockedResponse)
+      response = await Director.getSubscriber(streamName, accountId)
     })
 
     then('I get the subscriber connection path', async () => {

--- a/packages/millicast-sdk/tests/features/step-definitions/SubscribeOnUserCountEvent.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/SubscribeOnUserCountEvent.steps.js
@@ -1,25 +1,25 @@
 import { loadFeature, defineFeature } from 'jest-cucumber'
 import WS from 'jest-websocket-mock'
-import { eventsLocation, recordSeparator } from '../../../src/utils/EventSubscriber'
-
-let StreamEvents
-beforeEach(() => {
-  jest.isolateModules(() => {
-    StreamEvents = require('../../../src/StreamEvents').default
-  })
-})
+import { recordSeparator } from '../../../src/utils/EventSubscriber'
 
 const feature = loadFeature('../SubscribeOnUserCountEvent.feature', { loadRelativePath: true, errors: true })
 
 defineFeature(feature, test => {
+  const websocketTest = 'wss://localhost:29100/ws'
+  let StreamEvents
   let server = null
-  const handler = jest.fn()
+  let handler
 
-  beforeEach(async () => {
-    server = new WS(eventsLocation)
+  beforeEach(() => {
+    jest.isolateModules(() => {
+      StreamEvents = require('../../../src/StreamEvents').default
+    })
+    handler = jest.fn()
+    server = new WS(websocketTest)
+    StreamEvents.setEventsLocation(websocketTest)
   })
 
-  afterEach(async () => {
+  afterEach(() => {
     WS.clean()
     server = null
   })


### PR DESCRIPTION
Due to #87:
- In Director module:
  - Added `.setLiveDomain()` and `.getLiveDomain()` to set Director websocket domain response.
  - Added tests

- In PeerConnection module:
  - Added `.setTurnServerLocation()` and `.getTurnServerLocation()` to set from where to get TURN server.
  - Added tests

- In StreamEvents module:
  - Added `setEventsLocation()` and `getEventsLocation()` to set from where to get TURN server.
  - Added tests