### PR TITLE
Added Dictionary options object in signaling publish and subscribe

### DIFF
--- a/packages/millicast-sdk/package-lock.json
+++ b/packages/millicast-sdk/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@millicast/sdk",
-			"version": "0.1.11",
+			"version": "0.1.12",
 			"license": "See in LICENSE file",
 			"dependencies": {
 				"axios": "^0.21.1",

--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -127,7 +127,7 @@ export default class Publish extends BaseWebRTC {
     promises = await Promise.all([getLocalSDPPromise, signalingConnectPromise])
     const localSdp = promises[0]
 
-    const publishPromise = this.signaling.publish(localSdp, this.options.codec, this.options.record, this.options.sourceId)
+    const publishPromise = this.signaling.publish(localSdp, this.options)
     const setLocalDescriptionPromise = this.webRTCPeer.peer.setLocalDescription(this.webRTCPeer.sessionDescription)
     promises = await Promise.all([publishPromise, setLocalDescriptionPromise])
     let remoteSdp = promises[0]

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -127,7 +127,7 @@ export default class View extends BaseWebRTC {
     promises = await Promise.all([getLocalSDPPromise, signalingConnectPromise])
     const localSdp = promises[0]
 
-    const subscribePromise = this.signaling.subscribe(localSdp, this.options.multiplexedAudioTracks > 0, this.options.pinnedSourceId, this.options.excludedSourceIds)
+    const subscribePromise = this.signaling.subscribe(localSdp, { ...this.options, vad: this.options.multiplexedAudioTracks > 0 })
     const setLocalDescriptionPromise = this.webRTCPeer.peer.setLocalDescription(this.webRTCPeer.sessionDescription)
     promises = await Promise.all([subscribePromise, setLocalDescriptionPromise])
     const sdpSubscriber = promises[0]

--- a/packages/millicast-sdk/tests/features/OfferPublishingStream.feature
+++ b/packages/millicast-sdk/tests/features/OfferPublishingStream.feature
@@ -20,6 +20,11 @@ Feature: As a user I want to signal Millicast Server so I can offer publishing a
     When I offer my local sdp with av1 codec
     Then returns a filtered sdp to offer to remote peer
 
+  Scenario: Offer a SDP with no previous connection and options as object
+    Given a local sdp and no previous connection to server
+    When I offer my local sdp using options object
+    Then returns a filtered sdp to offer to remote peer
+
   Scenario: Offer a SDP with previous connection and h264 codec
     Given a local sdp and a previous active connection to server
     When I offer my local spd with h264 codec
@@ -54,8 +59,3 @@ Feature: As a user I want to signal Millicast Server so I can offer publishing a
     Given I have not previous connection to server
     When I offer a sdp
     Then returns a filtered sdp to offer to remote peer
-
-  Scenario: Signaling returns SDP with extmap-allow-mixed
-    Given I have not previous connection to server
-    When I offer a sdp
-    Then returns a filtered sdp to offer without extmap-allow-mixed

--- a/packages/millicast-sdk/tests/features/OfferSubscribingStream.feature
+++ b/packages/millicast-sdk/tests/features/OfferSubscribingStream.feature
@@ -4,6 +4,11 @@ Feature: As a user I want to signal Millicast Server so I can offer subscribing 
     Given a local sdp and no previous connection to server
     When I offer my local sdp
     Then returns a filtered sdp to offer to remote peer
+  
+  Scenario: Offer a SDP with no previous connection and options as object 
+    Given a local sdp and no previous connection to server
+    When I offer my local sdp using options object
+    Then returns a filtered sdp to offer to remote peer
 
   Scenario: Offer a SDP with previous connection
     Given a local sdp and a previous active connection to server

--- a/packages/millicast-sdk/tests/features/step-definitions/OfferPublishingStream.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/OfferPublishingStream.steps.js
@@ -346,6 +346,39 @@ defineFeature(feature, test => {
     })
   })
 
+  test('Offer a SDP with no previous connection and options as object', ({ given, when, then }) => {
+    let response
+
+    given('a local sdp and no previous connection to server', async () => {
+      jest.spyOn(TransactionManager.prototype, 'cmd').mockImplementation(() => {
+        return {
+          feedId: 12345,
+          publisherId,
+          sdp: offerSdp('av1'),
+          streamId: `${accountId}/${streamName}`,
+          uuid: 'feeds://uuid1234/5678'
+        }
+      })
+    })
+
+    when('I offer my local sdp using options object', async () => {
+      const signaling = new Signaling({
+        streamName: streamName,
+        url: publishWebSocketLocation
+      })
+      const signalingPublishOptions = {
+        codec: 'av1'
+      }
+      response = await signaling.publish(localSdp, signalingPublishOptions)
+    })
+
+    then('returns a filtered sdp to offer to remote peer', async () => {
+      expect(response).toBeDefined()
+      expect(response).toMatch('AV1X/90000')
+      expect(response).not.toMatch(/H264|VP8|VP9/)
+    })
+  })
+
   test('Offer a SDP with no codec', ({ given, when, then }) => {
     let response
 
@@ -370,34 +403,6 @@ defineFeature(feature, test => {
     })
 
     then('returns a filtered sdp to offer to remote peer', async () => {
-      expect(response).toBeDefined()
-      expect(response).toBe(offerSdp())
-    })
-  })
-  test('Signaling returns SDP with extmap-allow-mixed', ({ given, when, then }) => {
-    let response
-
-    given('I have not previous connection to server', async () => {
-      jest.spyOn(TransactionManager.prototype, 'cmd').mockImplementation(() => {
-        return {
-          feedId: 12345,
-          publisherId,
-          sdp: `${offerSdp()}\na=extmap-allow-mixed`,
-          streamId: `${accountId}/${streamName}`,
-          uuid: 'feeds://uuid1234/5678'
-        }
-      })
-    })
-
-    when('I offer a sdp', async () => {
-      const signaling = new Signaling({
-        streamName: streamName,
-        url: publishWebSocketLocation
-      })
-      response = await signaling.publish(localSdp)
-    })
-
-    then('returns a filtered sdp to offer without extmap-allow-mixed', async () => {
       expect(response).toBeDefined()
       expect(response).toBe(offerSdp())
     })

--- a/packages/millicast-sdk/tests/features/step-definitions/OfferSubscribingStream.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/OfferSubscribingStream.steps.js
@@ -89,6 +89,60 @@ defineFeature(feature, test => {
     })
   })
 
+  test('Offer a SDP with no previous connection and options as object', ({ given, when, then }) => {
+    let localSdp
+    let response
+
+    given('a local sdp and no previous connection to server', async () => {
+      localSdp = `v=0
+        o=alice 2890844526 2890844526 IN IP4 host.anywhere.com
+        s=
+        c=IN IP4 host.anywhere.com
+        t=0 0
+        m=audio 49170 RTP/AVP 0
+        a=rtpmap:0 PCMU/8000
+        m=video 51372 RTP/AVP 31
+        a=rtpmap:31 H261/90000
+        m=video 53000 RTP/AVP 32
+        a=rtpmap:32 MPV/90000
+        a=fmtp:124 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=4d001f
+        a=rtpmap:119 rtx/90000
+        a=fmtp:119 apt=124
+        a=rtpmap:123 H264/90000
+        a=rtcp-fb:123 goog-remb
+        a=rtcp-fb:123 transport-cc
+        a=rtcp-fb:123 ccm fir
+        a=rtcp-fb:123 nack
+        a=rtcp-fb:123 nack pli
+      `
+      jest.spyOn(TransactionManager.prototype, 'cmd').mockImplementation(() => {
+        return {
+          feedId: 12345,
+          publisherId,
+          sdp: offerSdp,
+          streamId: `${accountId}/${streamName}`,
+          uuid: 'feeds://uuid1234/5678'
+        }
+      })
+    })
+
+    when('I offer my local sdp using options object', async () => {
+      const signaling = new Signaling({
+        streamName: streamName,
+        url: publishWebSocketLocation
+      })
+      const signalingSubscribeOptions = {
+        vad: true
+      }
+      response = await signaling.subscribe(localSdp, signalingSubscribeOptions)
+    })
+
+    then('returns a filtered sdp to offer to remote peer', async () => {
+      expect(response).toBeDefined()
+      expect(response).toBe(offerSdp)
+    })
+  })
+
   test('Offer a SDP with previous connection', ({ given, when, then }) => {
     let localSdp
     let response


### PR DESCRIPTION
- Added Dictionary options object as parameter in `Signaling.publish` and `Signaling.subscribe`, keeping backward compatibility.  Due to issue #104 
   - Updated other parameters as deprecated.
- Removed `a=extmap-allow-mixed` check in `Signaling.publish`, since it was for a 2018 version of Chrome. Due to issue #102 
   - Removed `'Signaling returns SDP with extmap-allow-mixed'` test.