### PR TITLE
Feature: Support for Safari 12

### DIFF
--- a/packages/millicast-sdk/package-lock.json
+++ b/packages/millicast-sdk/package-lock.json
@@ -2980,9 +2980,9 @@
 			"dev": true
 		},
 		"core-js": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+			"version": "3.20.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.1.tgz",
+			"integrity": "sha512-btdpStYFQScnNVQ5slVcr858KP0YWYjV16eGJQw8Gg7CWtu/2qNvIM3qVRIR3n1pK2R9NNOrTevbvAYxajwEjg==",
 			"dev": true
 		},
 		"core-js-compat": {
@@ -8916,6 +8916,14 @@
 				"minimist": "^1.2.0",
 				"request": "^2.88.0",
 				"rx": "^4.1.0"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "2.6.12",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+					"dev": true
+				}
 			}
 		},
 		"wait-port": {

--- a/packages/millicast-sdk/package.json
+++ b/packages/millicast-sdk/package.json
@@ -57,6 +57,7 @@
 		"ua-parser-js": "^0.7.30"
 	},
 	"devDependencies": {
+		"core-js": "^3.20.1",
 		"@babel/core": "^7.13.10",
 		"@babel/helpers": "^7.13.10",
 		"@babel/plugin-transform-modules-commonjs": "^7.13.8",

--- a/packages/millicast-sdk/rollup.config.js
+++ b/packages/millicast-sdk/rollup.config.js
@@ -24,7 +24,22 @@ export default [
       json(),
       babel({
         babelHelpers: 'runtime',
-        presets: ['@babel/preset-env'],
+        presets: [
+          [
+            '@babel/preset-env',
+            {
+              targets: {
+                safari: '12',
+                firefox: '66'
+              },
+              useBuiltIns: 'usage',
+              corejs: {
+                version: pkg.devDependencies['core-js'],
+                proposals: false
+              }
+            }
+          ]
+        ],
         exclude: ['/node_modules/**'],
         plugins: ['@babel/plugin-transform-runtime']
       }),
@@ -50,7 +65,23 @@ export default [
       json(),
       babel({
         babelHelpers: 'bundled',
-        presets: [['@babel/preset-env', { targets: { node: 6 } }]],
+        presets: [
+          [
+            '@babel/preset-env',
+            {
+              targets: {
+                node: 6,
+                safari: '12',
+                firefox: '66'
+              },
+              useBuiltIns: 'usage',
+              corejs: {
+                version: pkg.devDependencies['core-js'],
+                proposals: false
+              }
+            }
+          ]
+        ],
         exclude: ['/node_modules/**']
       })
     ]

--- a/packages/millicast-sdk/tests/functional/PublishTest.js
+++ b/packages/millicast-sdk/tests/functional/PublishTest.js
@@ -7,6 +7,7 @@ const tokenGenerator = () => millicast.Director.getPublisher({ token, streamName
 
 class MillicastPublishTest {
   constructor () {
+    millicast.Logger.setLevel(millicast.Logger.DEBUG)
     this.streamCount = null
     this.millicastPublish = new millicast.Publish(streamName, tokenGenerator)
   }

--- a/packages/millicast-sdk/tests/functional/ViewTest.js
+++ b/packages/millicast-sdk/tests/functional/ViewTest.js
@@ -5,6 +5,7 @@ const streamName = window.streamName
 
 class MillicastViewTest {
   constructor () {
+    millicast.Logger.setLevel(millicast.Logger.DEBUG)
     const href = new URL(window.location.href)
     this.streamAccountId = (href.searchParams.get('streamAccountId')) ? href.searchParams.get('streamAccountId') : accountId
     this.streamName = (href.searchParams.get('streamName')) ? href.searchParams.get('streamName') : streamName


### PR DESCRIPTION
- Added core-js into Babel bundle configuration to support build from Safari 12 and beyond.
- Added bundle support from Firefox 66 and beyond.