### PR TITLE
Feature fix docs references

### DIFF
--- a/packages/millicast-sdk/src/Director.js
+++ b/packages/millicast-sdk/src/Director.js
@@ -37,7 +37,7 @@ let apiEndpoint = defaultApiEndpoint
  * For security reasosn all calls will return a [JWT](https://jwt.io) token forn authentication including the required
  * socket path to connect with.
  *
- * You will need your own Publishing token and Stream name, please refer to [Managing Your Tokens](https://dash.millicast.com/docs.html?pg=managing-your-tokens).
+ * You will need your own Publishing token and Stream name, please refer to [Managing Your Tokens](https://docs.millicast.com/docs/managing-your-tokens).
  * @namespace
  */
 

--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -28,7 +28,7 @@ const connectOptions = {
  *
  * - [MediaStream](https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API) which has at most one audio track and at most one video track. This will be used for stream the contained tracks.
  *
- * - A connection path that you can get from {@link Director} module or from your own implementation based on [Get a Connection Path](https://dash.millicast.com/docs.html?pg=how-to-broadcast-in-js#get-connection-paths-sect).
+ * - A connection path that you can get from {@link Director} module or from your own implementation.
  * @constructor
  * @param {String} streamName - Millicast existing stream name.
  * @param {tokenGeneratorCallback} tokenGenerator - Callback function executed when a new token is needed.

--- a/packages/millicast-sdk/src/Signaling.js
+++ b/packages/millicast-sdk/src/Signaling.js
@@ -137,7 +137,7 @@ export default class Signaling extends EventEmitter {
            *
            * Stopped - Fires when the live stream has been disconnected and is no longer available.
            *
-           * More information here: {@link https://dash.millicast.com/docs.html?pg=how-to-broadcast-in-js#broadcast-events-sect}
+           * More information here: {@link https://docs.millicast.com/docs/web-draft#broadcast-events}
            *
            * @event Signaling#broadcastEvent
            * @type {Object}

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -19,7 +19,7 @@ const connectOptions = {
  *
  * Before you can view an active broadcast, you will need:
  *
- * - A connection path that you can get from {@link Director} module or from your own implementation based on [Get a Connection Path](https://dash.millicast.com/docs.html?pg=how-to-broadcast-in-js#get-connection-paths-sect).
+ * - A connection path that you can get from {@link Director} module or from your own implementation.
  * @constructor
  * @param {String} streamName - Millicast existing Stream Name where you want to connect.
  * @param {tokenGeneratorCallback} tokenGenerator - Callback function executed when a new token is needed.


### PR DESCRIPTION
Removed old docs URL references (https://dash.millicast.com/docs.html) and added the new ones (https://docs.millicast.com/docs) in Director.js, Publish.js, Signaling.js, and View.js
