### PR TITLE
Fixed addRemoteTrack for firefox

### DIFF
--- a/packages/millicast-sdk/src/PeerConnection.js
+++ b/packages/millicast-sdk/src/PeerConnection.js
@@ -446,6 +446,7 @@ const addPeerEvents = (instanceClass, peer) => {
     logger.info('Peer onnegotiationneeded, updating local description')
     const offer = await peer.createOffer()
     logger.info('Peer onnegotiationneeded, got local offer', offer.sdp)
+    offer.sdp = SdpParser.updateMissingVideoExtensions(offer.sdp, peer.remoteDescription.sdp)
     await peer.setLocalDescription(offer)
     const sdp = SdpParser.renegotiate(offer.sdp, peer.remoteDescription.sdp)
     logger.info('Peer onnegotiationneeded, updating remote description', sdp)


### PR DESCRIPTION
- Created `updateMissingVideoExtensions` function to the SdpParser that adds missing video extensions to the sdp for the renegotiation.
- Added `updateMissingVideoExtensions` in `peer.onnegotiationneeded` before setting the local description to add the missing video extensions to the offer.