### PR TITLE
Add H.265 support if the browser supports H.265

### DIFF
--- a/packages/millicast-sdk/src/Signaling.js
+++ b/packages/millicast-sdk/src/Signaling.js
@@ -2,6 +2,7 @@ import EventEmitter from 'events'
 import TransactionManager from 'transaction-manager'
 import Logger from './Logger'
 import SdpParser from './utils/SdpParser'
+import PeerConnection from './PeerConnection'
 
 const logger = Logger.get('Signaling')
 
@@ -263,11 +264,17 @@ export default class Signaling extends EventEmitter {
 
     logger.info(`Starting publishing to streamName: ${this.streamName}, codec: ${optionsParsed.codec}`)
     logger.debug('Publishing local description: ', sdp)
+    const supportedVideoCodecs = PeerConnection.getCapabilities?.('video')?.codecs?.map(cdc => cdc.codec) ?? []
 
     const videoCodecs = Object.values(VideoCodec)
     if (videoCodecs.indexOf(optionsParsed.codec) === -1) {
-      logger.error('Invalid codec. Possible values are: ', videoCodecs)
-      throw new Error(`Invalid codec. Possible values are: ${videoCodecs}`)
+      logger.error(`Invalid codec ${optionsParsed.codec}. Possible values are: `, videoCodecs)
+      throw new Error(`Invalid codec ${optionsParsed.codec}. Possible values are: ${videoCodecs}`)
+    }
+
+    if (supportedVideoCodecs.length > 0 && supportedVideoCodecs.indexOf(optionsParsed.codec) === -1) {
+      logger.error(`Unsupported codec ${optionsParsed.codec}. Possible values are: `, supportedVideoCodecs)
+      throw new Error(`Unsupported codec ${optionsParsed.codec}. Possible values are: ${supportedVideoCodecs}`)
     }
 
     // Signaling server only recognizes 'AV1' and not 'AV1X'

--- a/packages/millicast-sdk/src/Signaling.js
+++ b/packages/millicast-sdk/src/Signaling.js
@@ -2,7 +2,6 @@ import EventEmitter from 'events'
 import TransactionManager from 'transaction-manager'
 import Logger from './Logger'
 import SdpParser from './utils/SdpParser'
-import UserAgent from './utils/UserAgent'
 
 const logger = Logger.get('Signaling')
 
@@ -27,7 +26,8 @@ export const VideoCodec = {
   VP8: 'vp8',
   VP9: 'vp9',
   H264: 'h264',
-  AV1: 'av1'
+  AV1: 'av1',
+  H265: 'h265'
 }
 
 /**
@@ -92,10 +92,6 @@ export default class Signaling extends EventEmitter {
     this.transactionManager = null
     this.serverId = null
     this.clusterId = null
-    const browserData = new UserAgent()
-    if (browserData.isSafari()) {
-      VideoCodec.H265 = 'h265'
-    }
   }
 
   /**

--- a/packages/millicast-sdk/tests/features/GetCapabilities.feature
+++ b/packages/millicast-sdk/tests/features/GetCapabilities.feature
@@ -1,22 +1,22 @@
 Feature: As a user I want to get browser audio/video capabilities so I can choose the codec to start broadcasting
 
   Scenario: Browser supports more codecs than Millicast
-    Given my browser supprots H264, H265
+    Given my browser supports H264, H265, red and rtx
     When I get video capabilities
-    Then returns H264 in codecs property
+    Then returns H264 and H265 in codecs property
   
   Scenario: Browser supports all codecs of Millicast
-    Given my browser supprots H264, H265, VP8, VP9 and AV1
+    Given my browser supports H264, H265, VP8, VP9 and AV1
     When I get video capabilities
-    Then returns all codecs except H265
+    Then returns all codecs
 
   Scenario: Browser supports SVC for VP9
-    Given my browser supprots VP9 with scalability modes
+    Given my browser supports VP9 with scalability modes
     When I get video capabilities
     Then returns VP9 with all scalability modes available
 
   Scenario: Browser supports SVC for VP9 repeated layers
-    Given my browser supprots VP9 with scalability modes repeated
+    Given my browser supports VP9 with scalability modes repeated
     When I get video capabilities
     Then returns VP9 with all scalability modes available
 

--- a/packages/millicast-sdk/tests/features/Publish.feature
+++ b/packages/millicast-sdk/tests/features/Publish.feature
@@ -20,6 +20,16 @@ Feature: As a user I want to publish a stream without managing connections
     When I broadcast a stream without options
     Then throws an error
 
+  Scenario: Broadcast with invalid codec
+    Given an instance of Publish
+    When I broadcast with unsupported codec
+    Then throws an error
+
+  Scenario: Broadcast with non-default codec
+    Given an instance of Publish
+    When I broadcast a stream with H265 codec
+    Then peer connection state is connected    
+    
   Scenario: Broadcast without connection path
     Given I want to broadcast
     When I instance a Publish with token generator without connection path

--- a/packages/millicast-sdk/tests/features/step-definitions/GetCapabilites.steps.js
+++ b/packages/millicast-sdk/tests/features/step-definitions/GetCapabilites.steps.js
@@ -20,12 +20,14 @@ defineFeature(feature, test => {
       codecs: [
         { clockRate: 90000, mimeType: 'video/H264', sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=0;profile-level-id=42001f' },
         { clockRate: 90000, mimeType: 'video/H264', sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f' },
-        { clockRate: 90000, mimeType: 'video/H265', sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f' }
+        { clockRate: 90000, mimeType: 'video/H265', sdpFmtpLine: 'level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f' },
+        { clockRate: 90000, mimeType: 'video/rtx' },
+        { clockRate: 90000, mimeType: 'video/red' }
       ],
       headerExtensions: []
     }
 
-    given('my browser supprots H264, H265', async () => {
+    given('my browser supports H264, H265, red and rtx', async () => {
       jest.spyOn(RTCRtpSender, 'getCapabilities').mockReturnValue({ ...browserCapabilities })
     })
 
@@ -33,8 +35,11 @@ defineFeature(feature, test => {
       capabilities = PeerConnection.getCapabilities('video')
     })
 
-    then('returns H264 in codecs property', async () => {
-      expect(capabilities.codecs).toEqual([{ codec: 'h264', mimeType: 'video/H264' }])
+    then('returns H264 and H265 in codecs property', async () => {
+      expect(capabilities.codecs).toEqual([
+        { codec: 'h264', mimeType: 'video/H264' },
+        { codec: 'h265', mimeType: 'video/H265' }
+      ])
       expect(capabilities.headerExtensions).toEqual(browserCapabilities.headerExtensions)
     })
   })
@@ -55,7 +60,7 @@ defineFeature(feature, test => {
       headerExtensions: []
     }
 
-    given('my browser supprots H264, H265, VP8, VP9 and AV1', async () => {
+    given('my browser supports H264, H265, VP8, VP9 and AV1', async () => {
       jest.spyOn(RTCRtpSender, 'getCapabilities').mockReturnValue({ ...browserCapabilities })
     })
 
@@ -63,11 +68,12 @@ defineFeature(feature, test => {
       capabilities = PeerConnection.getCapabilities('video')
     })
 
-    then('returns all codecs except H265', async () => {
+    then('returns all codecs', async () => {
       expect(capabilities.codecs).toEqual([
         { codec: 'vp8', mimeType: 'video/VP8' },
         { codec: 'vp9', mimeType: 'video/VP9' },
         { codec: 'h264', mimeType: 'video/H264' },
+        { codec: 'h265', mimeType: 'video/H265' },
         { codec: 'av1', mimeType: 'video/AV1X' }
       ])
       expect(capabilities.headerExtensions).toEqual(browserCapabilities.headerExtensions)
@@ -85,7 +91,7 @@ defineFeature(feature, test => {
       headerExtensions: []
     }
 
-    given('my browser supprots VP9 with scalability modes', async () => {
+    given('my browser supports VP9 with scalability modes', async () => {
       jest.spyOn(RTCRtpSender, 'getCapabilities').mockReturnValue({ ...browserCapabilities })
     })
 
@@ -112,7 +118,7 @@ defineFeature(feature, test => {
       headerExtensions: []
     }
 
-    given('my browser supprots VP9 with scalability modes repeated', async () => {
+    given('my browser supports VP9 with scalability modes repeated', async () => {
       jest.spyOn(RTCRtpSender, 'getCapabilities').mockReturnValue({ ...browserCapabilities })
     })
 


### PR DESCRIPTION
Previously the SDK was able to broadcast with H.265 but was not able to publish it when queried with `PeerConnection.getCapabilities('video')`. 

Now the SDK will return `H.265` if the browser supports it. 

Tested on Chrome, Edge, Firefox and Safari on MacOS - h.265 only showed up on safari when the experimental flag was enaabled. 

