### PR TITLE
Fix in reconnection method

### DIFF
--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -154,11 +154,11 @@ export default class Publish extends BaseWebRTC {
     } catch (error) {
       logger.error('Error generating token.')
       if (error instanceof FetchError) {
-        if (error.status === 401) {
+        if (error.status === 401 || !this.autoReconnect) {
           // should not reconnect
           this.stopReconnection = true
         } else {
-          // should reconnect with exponential back off
+          // should reconnect with exponential back off if autoReconnect is true
           this.reconnect()
         }
       }

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -201,11 +201,11 @@ export default class View extends BaseWebRTC {
     } catch (error) {
       logger.error('Error generating token.')
       if (error instanceof FetchError) {
-        if (error.status === 401) {
+        if (error.status === 401 || !this.autoReconnect) {
           // should not reconnect
           this.stopReconnection = true
         } else {
-          // should reconnect with exponential back off
+          // should reconnect with exponential back off if autoReconnect is true
           this.reconnect()
         }
       }

--- a/packages/millicast-sdk/src/utils/BaseWebRTC.js
+++ b/packages/millicast-sdk/src/utils/BaseWebRTC.js
@@ -123,7 +123,7 @@ export default class BaseWebRTC extends EventEmitter {
   async reconnect (data) {
     try {
       logger.info('Attempting to reconnect...')
-      if (!this.isActive() && this.autoReconnect && !this.stopReconnection && !this.isReconnecting) {
+      if (!this.isActive() && !this.stopReconnection && !this.isReconnecting) {
         this.stop()
         /**
          * Emits with every reconnection attempt made when an active stream


### PR DESCRIPTION
The `autoReconnect` variable was not being checked in the reconnect method so when trying to reconnect, it was attempting besides the option of `autoReconnect`.

This fixes issue #292 