### PR TITLE
Rollback iCloud Private Relay

### DIFF
--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -4,7 +4,6 @@ import BaseWebRTC from './utils/BaseWebRTC'
 import Signaling, { signalingEvents } from './Signaling'
 import PeerConnection, { webRTCEvents } from './PeerConnection'
 import FetchError from './utils/FetchError'
-import UserAgent from './utils/UserAgent'
 
 const logger = Logger.get('View')
 
@@ -194,11 +193,6 @@ export default class View extends BaseWebRTC {
       subscriberData = await this.tokenGenerator()
       //  Set the iceServers from the subscribe data into the peerConfig
       this.options.peerConfig.iceServers = subscriberData?.iceServers
-      // Only for Safari when iCloud Private Relay is enabled, this policy is needed
-      const browserData = new UserAgent()
-      if (browserData.isSafari()) {
-        this.options.peerConfig.iceTransportPolicy = 'relay'
-      }
     } catch (error) {
       logger.error('Error generating token.')
       if (error instanceof FetchError) {


### PR DESCRIPTION
The fix was made for all Safari users, which impoverishes the user experience by being redirected to a TURN server that give worse network connection. To solve the issue, a fix has been made in the server to avoid getting the original bug. 