### PR TITLE
Deprecated streamName in constructor of publish and view

### DIFF
--- a/.changeset/rude-plants-agree.md
+++ b/.changeset/rude-plants-agree.md
@@ -1,0 +1,5 @@
+---
+"@millicast/sdk": patch
+---
+
+Deprecated the streamName argument in publish and view

--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -34,7 +34,8 @@ const connectOptions = {
  *
  * - A connection path that you can get from {@link Director} module or from your own implementation.
  * @constructor
- * @param {String} streamName - Millicast existing stream name.
+ * @deprecated streamName is no longer used, use tokenGenerator
+ * @param {String} streamName - Deprecated: Millicast existing stream name.
  * @param {tokenGeneratorCallback} tokenGenerator - Callback function executed when a new token is needed.
  * @param {Boolean} [autoReconnect=true] - Enable auto reconnect to stream.
  */
@@ -77,6 +78,7 @@ export default class Publish extends BaseWebRTC {
    * const tokenGenerator = () => getYourPublisherConnection(token, streamName)
    *
    * //Create a new instance
+   * // streamName is not necessary in the constructor anymore, could be null or undefined
    * const streamName = "My Millicast Stream Name"
    * const millicastPublish = new Publish(streamName, tokenGenerator)
    *
@@ -196,7 +198,9 @@ export default class Publish extends BaseWebRTC {
       logger.error('Error while broadcasting. Publisher data required')
       throw new Error('Publisher data required')
     }
-    this.recordingAvailable = jwtDecode(publisherData.jwt)[atob('bWlsbGljYXN0')].record
+    const decodedJWT = jwtDecode(publisherData.jwt)
+    this.streamName = decodedJWT.millicast.streamName
+    this.recordingAvailable = decodedJWT[atob('bWlsbGljYXN0')].record
     if (this.options.record && !this.recordingAvailable) {
       logger.error('Error while broadcasting. Record option detected but recording is not available')
       throw new Error('Record option detected but recording is not available')

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -1,4 +1,5 @@
 import reemit from 're-emitter'
+import jwtDecode from 'jwt-decode'
 import Logger from './Logger'
 import BaseWebRTC from './utils/BaseWebRTC'
 import Signaling, { signalingEvents } from './Signaling'
@@ -23,7 +24,8 @@ const connectOptions = {
  *
  * - A connection path that you can get from {@link Director} module or from your own implementation.
  * @constructor
- * @param {String} streamName - Millicast existing Stream Name where you want to connect.
+ * @deprecated streamName is no longer used, use tokenGenerator
+ * @param {String} streamName - Deprecated: Millicast existing stream name.
  * @param {tokenGeneratorCallback} tokenGenerator - Callback function executed when a new token is needed.
  * @param {HTMLMediaElement} [mediaElement=null] - Target HTML media element to mount stream.
  * @param {Boolean} [autoReconnect=true] - Enable auto reconnect to stream.
@@ -80,6 +82,7 @@ export default class View extends BaseWebRTC {
    * const tokenGenerator = () => getYourSubscriberInformation(accountId, streamName)
    *
    * //Create a new instance
+   * // Stream name is not necessary in the constructor anymore, could be null | undefined
    * const streamName = "Millicast Stream Name where i want to connect"
    * const millicastView = new View(streamName, tokenGenerator, videoElement)
    *
@@ -210,6 +213,8 @@ export default class View extends BaseWebRTC {
       logger.error('Error while subscribing. Subscriber data required')
       throw new Error('Subscriber data required')
     }
+    const decodedJWT = jwtDecode(subscriberData.jwt)
+    this.streamName = decodedJWT.millicast.streamName
     const signalingInstance = new Signaling({
       streamName: this.streamName,
       url: `${subscriberData.urls[0]}?token=${subscriberData.jwt}`

--- a/packages/millicast-sdk/src/utils/BaseWebRTC.js
+++ b/packages/millicast-sdk/src/utils/BaseWebRTC.js
@@ -28,7 +28,8 @@ const baseInterval = 1000
  * @classdesc Base class for common actions about peer connection and reconnect mechanism for Publishers and Viewer instances.
  *
  * @constructor
- * @param {String} streamName - Millicast existing stream name.
+ * @deprecated streamName is no longer used, use tokenGenerator
+ * @param {String} streamName - Deprecated: Millicast existing stream name.
  * @param {tokenGeneratorCallback} tokenGenerator - Callback function executed when a new token is needed.
  * @param {Object} loggerInstance - Logger instance from the extended classes.
  * @param {Boolean} autoReconnect - Enable auto reconnect.
@@ -37,17 +38,12 @@ export default class BaseWebRTC extends EventEmitter {
   constructor (streamName, tokenGenerator, loggerInstance, autoReconnect) {
     super()
     logger = loggerInstance
-    if (!streamName) {
-      logger.error('Stream Name is required to construct this module.')
-      throw new Error('Stream Name is required to construct this module.')
-    }
     if (!tokenGenerator) {
       logger.error('Token generator is required to construct this module.')
       throw new Error('Token generator is required to construct this module.')
     }
     this.webRTCPeer = new PeerConnection()
     this.signaling = null
-    this.streamName = streamName
     this.autoReconnect = autoReconnect
     this.reconnectionInterval = baseInterval
     this.alreadyDisconnected = false

--- a/packages/millicast-sdk/tests/features/Publish.feature
+++ b/packages/millicast-sdk/tests/features/Publish.feature
@@ -1,10 +1,5 @@
 Feature: As a user I want to publish a stream without managing connections
 
-  Scenario: Instance publisher without streamName
-    Given no stream name
-    When I instance a Publish
-    Then throws an error
-
   Scenario: Instance publisher without tokenGenerator
     Given no token generator
     When I instance a Publish

--- a/packages/millicast-sdk/tests/features/View.feature
+++ b/packages/millicast-sdk/tests/features/View.feature
@@ -1,10 +1,5 @@
 Feature: As a user I want to subscribe to a stream without managing connections
 
-  Scenario: Instance viewer without streamName
-    Given no stream name
-    When I instance a View
-    Then throws an error
-  
   Scenario: Instance viewer without tokenGenerator
     Given no token generator
     When I instance a View

--- a/packages/millicast-sdk/tests/unit/Publish.steps.js
+++ b/packages/millicast-sdk/tests/unit/Publish.steps.js
@@ -23,21 +23,6 @@ const mockTokenGenerator = jest.fn(() => {
 const mediaStream = new MediaStream([{ kind: 'video' }, { kind: 'audio' }])
 
 defineFeature(feature, test => {
-  test('Instance publisher without streamName', ({ given, when, then }) => {
-    let expectError
-
-    given('no stream name', () => null)
-
-    when('I instance a Publish', async () => {
-      expectError = expect(() => new Publish())
-    })
-
-    then('throws an error', async () => {
-      expectError.toThrow(Error)
-      expectError.toThrow('Stream Name is required to construct this module.')
-    })
-  })
-
   test('Instance publisher without tokenGenerator', ({ given, when, then }) => {
     let expectError
 

--- a/packages/millicast-sdk/tests/unit/View.steps.js
+++ b/packages/millicast-sdk/tests/unit/View.steps.js
@@ -18,21 +18,6 @@ const mockTokenGenerator = jest.fn(() => {
 })
 
 defineFeature(feature, test => {
-  test('Instance viewer without streamName', ({ given, when, then }) => {
-    let expectError
-
-    given('no stream name', () => null)
-
-    when('I instance a View', async () => {
-      expectError = expect(() => new View())
-    })
-
-    then('throws an error', async () => {
-      expectError.toThrow(Error)
-      expectError.toThrow('Stream Name is required to construct this module.')
-    })
-  })
-
   test('Instance viewer without tokenGenerator', ({ given, when, then }) => {
     let expectError
 

--- a/packages/millicast-sdk/tests/unit/__mocks__/jwt-decode.js
+++ b/packages/millicast-sdk/tests/unit/__mocks__/jwt-decode.js
@@ -5,7 +5,7 @@ const dummyToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODk
 jwtDecodeMock.mockImplementation((token) => {
   return {
     millicast: {
-      streamName: 'Unexisting_stream_name',
+      streamName: 'test-stream',
       jwt: dummyToken
     }
   }

--- a/packages/millicast-sdk/tests/unit/__mocks__/jwt-decode.js
+++ b/packages/millicast-sdk/tests/unit/__mocks__/jwt-decode.js
@@ -1,0 +1,14 @@
+const jwtDecodeMock = jest.fn()
+
+const dummyToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJtaWxsaWNhc3QiOnt9fQ.IqT-PLLz-X7Wn7BNo-x4pFApAbMT9mmnlupR8eD9q4U'
+
+jwtDecodeMock.mockImplementation((token) => {
+  return {
+    millicast: {
+      streamName: 'Unexisting_stream_name',
+      jwt: dummyToken
+    }
+  }
+})
+
+export default jwtDecodeMock


### PR DESCRIPTION
Since we already have tokenGenerator which will validate the stream name, we could use that streamName as the single truth. We should remove this argument from constructor in future release.