### PR TITLE
Throw error with wrong codec for metadata

### DIFF
--- a/packages/millicast-sdk/src/utils/Codecs.js
+++ b/packages/millicast-sdk/src/utils/Codecs.js
@@ -563,7 +563,7 @@ function createSEIMessageContentWithPrevensionBytes (content) {
   return new Uint8Array(preventionByteArray)
 }
 
-function createSEINalu ({ uuid, payload }, codec) {
+function createSEINalu ({ uuid, payload }) {
   const startCode = [0x00, 0x00, 0x00, 0x01]
   const header = [0x66] // 0b01100110
   const content = createSEIMessageContent(uuid, payload)
@@ -579,15 +579,16 @@ function createSEINalu ({ uuid, payload }, codec) {
   return naluWithSEI
 }
 
-export function addH26xSEI ({ uuid, payload }, encodedFrame, codec) {
-  if (codec !== 'h264' && codec !== 'h265') {
+export function addH26xSEI ({ uuid, payload }, encodedFrame) {
+  const codec = encodedFrame.getMetadata().mimeType
+  if (codec !== 'video/H264' && codec !== 'video/H265') {
     throw new Error(`Unsupported codec ${codec}`)
   }
   if (uuid === '' || payload === '') {
     throw new Error('uuid and payload cannot be empty')
   }
   // Case of NALU H264 - User Unregistered Data
-  const naluWithSEI = createSEINalu({ uuid, payload }, codec)
+  const naluWithSEI = createSEINalu({ uuid, payload })
 
   const encodedFrameView = new DataView(encodedFrame.data)
   const encodedFrameWithSEI = new ArrayBuffer(encodedFrame.data.byteLength + naluWithSEI.byteLength)

--- a/packages/millicast-sdk/src/utils/Codecs.js
+++ b/packages/millicast-sdk/src/utils/Codecs.js
@@ -582,7 +582,7 @@ function createSEINalu ({ uuid, payload }) {
 export function addH26xSEI ({ uuid, payload }, encodedFrame) {
   const codec = encodedFrame.getMetadata().mimeType
   if (codec !== 'video/H264' && codec !== 'video/H265') {
-    throw new Error(`Unsupported codec ${codec}`)
+    throw new Error('Sending metadata is not supported with any other codec other than H264 or H265')
   }
   if (uuid === '' || payload === '') {
     throw new Error('uuid and payload cannot be empty')

--- a/packages/millicast-sdk/src/workers/TransformWorker.worker.js
+++ b/packages/millicast-sdk/src/workers/TransformWorker.worker.js
@@ -23,9 +23,14 @@ function createSenderTransform () {
     flush () {},
     async transform (encodedFrame, controller) {
       if (uuid && payload) {
-        addH26xSEI({ uuid, payload }, encodedFrame, 'h264')
-        uuid = ''
-        payload = ''
+        try {
+          addH26xSEI({ uuid, payload }, encodedFrame)
+        } catch (error) {
+          console.error(error)
+        } finally {
+          uuid = ''
+          payload = ''
+        }
       }
       controller.enqueue(encodedFrame)
     }


### PR DESCRIPTION
The `RTCEncodedVideoFrame` captured in the worker for inserting metadata has a `getMetadata()` method that return an object with the `mimeType` as one of their attributes. This shows what codec is publishing, with what we can check before inserting and throwing corresponding error if necessary.