### PR TITLE
Throw error when simulcast cannot be set due to compatibility

### DIFF
--- a/packages/millicast-sdk/src/utils/SdpParser.js
+++ b/packages/millicast-sdk/src/utils/SdpParser.js
@@ -41,12 +41,10 @@ const SdpParser = {
     logger.info('Setting simulcast. Codec: ', codec)
     const browserData = new UserAgent()
     if (!browserData.isChromium()) {
-      logger.warn('Simulcast is only available in Chromium based browser')
-      return sdp
+      throw new Error('Simulcast is only available in Chromium based browser')
     }
     if (codec !== 'h264' && codec !== 'vp8') {
-      logger.warn('Simulcast is only available in h264 and vp8 codecs')
-      return sdp
+      throw new Error('Simulcast is only available in h264 and vp8 codecs')
     }
 
     try {

--- a/packages/millicast-sdk/src/utils/SdpParser.js
+++ b/packages/millicast-sdk/src/utils/SdpParser.js
@@ -41,10 +41,12 @@ const SdpParser = {
     logger.info('Setting simulcast. Codec: ', codec)
     const browserData = new UserAgent()
     if (!browserData.isChromium()) {
-      throw new Error('Simulcast is only available in Chromium based browser')
+      logger.warn('Your browser does not appear to support Simulcast. For a better experience, use a Chromium based browser.')
+      return sdp
     }
     if (codec !== 'h264' && codec !== 'vp8') {
-      throw new Error('Simulcast is only available in h264 and vp8 codecs')
+      logger.warn('Your selected codec does not appear to support Simulcast. For a better experience, use H.264 and VP8 codecs.')
+      return sdp
     }
 
     try {

--- a/packages/millicast-sdk/src/utils/SdpParser.js
+++ b/packages/millicast-sdk/src/utils/SdpParser.js
@@ -45,7 +45,7 @@ const SdpParser = {
       return sdp
     }
     if (codec !== 'h264' && codec !== 'vp8') {
-      logger.warn('Your selected codec does not appear to support Simulcast. For a better experience, use H.264 and VP8 codecs.')
+      logger.warn(`Your selected codec ${codec} does not appear to support Simulcast.  To broadcast using simulcast, please use H.264 or VP8.`)
       return sdp
     }
 


### PR DESCRIPTION
@dubeyShivank / @j12y we should review if you should throw an error and prevent from connecting or log the error and continue without setting simulcast.