### PR TITLE
Prevent metadata SEI extraction from codec - payload type mapping

### DIFF
--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -249,12 +249,13 @@ export default class View extends BaseWebRTC {
       const worker = new Worker(workerURL)
       if (supportsRTCRtpScriptTransform) {
         // eslint-disable-next-line no-undef
-        trackEvent.receiver.transform = new RTCRtpScriptTransform(worker, { name: 'receiverTransform', codecMap: this.codecPayloadTypeMap })
+        trackEvent.receiver.transform = new RTCRtpScriptTransform(worker, { name: 'receiverTransform', codecMap: this.codecPayloadTypeMap, codec: this.options.codec })
       } else if (supportsInsertableStreams) {
         const { readable, writable } = trackEvent.receiver.createEncodedStreams()
         worker.postMessage({
           action: 'insertable-streams-receiver',
           codecMap: this.codecPayloadTypeMap,
+          codec: this.options.codec,
           readable,
           writable
         }, [readable, writable])

--- a/packages/millicast-sdk/src/utils/Codecs.js
+++ b/packages/millicast-sdk/src/utils/Codecs.js
@@ -51,7 +51,7 @@ const SEI_Payload_Type = {
 export const DOLBY_SEI_DATA_UUID = '6e9cfd2a-5907-49ff-b363-8978a6e8340e'
 export const DOLBY_SEI_TIMESTAMP_UUID = '9a21f3be-31f0-4b78-b0be-c7f7dbb97250'
 class SPSState {
-  constructor (codec = 'h264') {
+  constructor (codec = 'H264') {
     this.sps = new Map()
     this.pps = new Map()
     this.activeSPS = null
@@ -59,7 +59,7 @@ class SPSState {
   }
 
   collectPPS (rbsp) {
-    if (this.codec === 'h264') {
+    if (this.codec === 'H264') {
       this.collectH264PPS(rbsp)
     } else {
       this.collectH265PPS(rbsp)
@@ -67,7 +67,7 @@ class SPSState {
   }
 
   collectSPS (rbsp) {
-    if (this.codec === 'h264') {
+    if (this.codec === 'H264') {
       this.collectH264SPS(rbsp)
     } else {
       this.collectH265SPS(rbsp)
@@ -291,7 +291,7 @@ function removePreventionBytes (ebsp) {
 
 function getNalus (frameBuffer, codec) {
   let offset = 0
-  const headerSize = codec === 'h264' ? 1 : 2
+  const headerSize = codec === 'H264' ? 1 : 2
   const nalus = []
   while (offset < frameBuffer.byteLength - 4) {
     const startCodeIndex = findStartCodeIndex(frameBuffer, offset)
@@ -318,9 +318,9 @@ function getSeiNalus (frameBuffer, codec) {
   let shouldSearchActiveSPS = true
   return getNalus(frameBuffer, codec).filter((nalu) => {
     const startCodeLength = nalu[2] === 0x01 ? 3 : 4
-    const headerLength = codec === 'h264' ? 1 : 2
+    const headerLength = codec === 'H264' ? 1 : 2
     const header = nalu[startCodeLength]
-    const naluType = codec === 'h264' ? header & 0x1f : header >> 1 & 0x3f
+    const naluType = codec === 'H264' ? header & 0x1f : header >> 1 & 0x3f
     if (shouldSearchActiveSPS) {
       switch (naluType) {
         case NALUType.PPS_H264:
@@ -501,18 +501,18 @@ function getSeiPicTimingTimecode (metadata, payloadContent) {
 /**
 * Extract user unregistered metadata from H26x Encoded Frame
 * @param { RTCEncodedFrame } encodedFrame
-* @param { 'h264' | 'h265' } codec
+* @param { 'H264' | 'H265' } codec
 * @returns { FrameMetaData }
 */
 export function extractH26xMetadata (encodedFrame, codec) {
-  if (codec !== 'h264' && codec !== 'h265') {
+  if (codec !== 'H264' && codec !== 'H265') {
     throw new Error(`Unsupported codec ${codec}`)
   }
   const metadata = {}
   spsState.codec = codec
   getSeiNalus(new Uint8Array(encodedFrame.data), codec).forEach((nalu) => {
     const startCodeLength = nalu[2] === 0x01 ? 3 : 4
-    const headerLength = codec === 'h264' ? 1 : 2
+    const headerLength = codec === 'H264' ? 1 : 2
     const rbsp = removePreventionBytes(nalu.subarray(startCodeLength + headerLength))
     const payload = extractSEIPayload(rbsp)
     switch (payload.type) {

--- a/packages/millicast-sdk/src/utils/SdpParser.js
+++ b/packages/millicast-sdk/src/utils/SdpParser.js
@@ -379,6 +379,16 @@ const SdpParser = {
       })
     }
     return localDescription
+  },
+  getCodecPayloadType (sdp) {
+    const reg = /a=rtpmap:(\d+) (\w+)\/\d+/g
+    const matches = sdp.matchAll(reg)
+    const codecMap = {}
+
+    for (const match of matches) {
+      codecMap[match[1]] = match[2]
+    }
+    return codecMap
   }
 }
 

--- a/packages/millicast-sdk/src/workers/TransformWorker.worker.js
+++ b/packages/millicast-sdk/src/workers/TransformWorker.worker.js
@@ -10,7 +10,7 @@ function createReceiverTransform () {
     start () {},
     flush () {},
     async transform (encodedFrame, controller) {
-      const frameCodec = codecMap[encodedFrame.getMetadata().payloadType]
+      const frameCodec = codecMap[encodedFrame.getMetadata().payloadType] || codec.toUpperCase()
       if (frameCodec === 'H264') {
         const metadata = extractH26xMetadata(encodedFrame, frameCodec)
         if (metadata.timecode || metadata.unregistered || metadata.seiPicTimingTimeCodeArray?.length > 0) {
@@ -60,6 +60,7 @@ addEventListener('rtctransform', (event) => {
     transform = createSenderTransform()
   } else if (event.transformer.options.name === 'receiverTransform') {
     codecMap = event.transformer.options.codecMap || {}
+    codec = event.transformer.options.codec || ''
     transform = createReceiverTransform()
   } else {
     return
@@ -76,6 +77,7 @@ addEventListener('message', (event) => {
       break
     case 'insertable-streams-receiver':
       codecMap = event.data.codecMap || {}
+      codec = event.data.codec || ''
       setupPipe(event.data, createReceiverTransform())
       break
     case 'metadata-sei-user-data-unregistered':


### PR DESCRIPTION
Should close #350 and replace it with this one.

Created an object in View instance to gather the SDP mapping of codec - payload type so that this is saved in the worker, and looked at when an encoded frame comes in.