### PR TITLE
Fix / All sources not shown when multiview enabled

### DIFF
--- a/packages/millicast-multiview-demo/src/multiviewer.js
+++ b/packages/millicast-multiview-demo/src/multiviewer.js
@@ -22,7 +22,7 @@ let transceiverToLayersMap = {}
 
 // Create a new viewer instance
 const tokenGenerator = () => Director.getSubscriber(streamName, accountId)
-const viewer = new View(streamName, tokenGenerator)
+const viewer = window.millicastView = new View(streamName, tokenGenerator)
 
 // Listen for broadcast events
 viewer.on('broadcastEvent', (event) => {
@@ -58,6 +58,10 @@ viewer.on('track', (event) => {
   if (event.streams.length > 0 && event.track.kind === 'video') {
     addStreamToVideoElement(event.streams[0], event.transceiver.mid)
   }
+})
+
+viewer.on('onMetadata', (metadata) => {
+  console.log(`Metadata event from ${transceiverToSourceIdMap[metadata.mid] || 'main'}:`, metadata)
 })
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/packages/millicast-multiview-demo/src/multiviewer.js
+++ b/packages/millicast-multiview-demo/src/multiviewer.js
@@ -101,21 +101,26 @@ const addRemoteSource = async (data) => {
 }
 
 const addMainSource = async (data) => {
-  const mediaStream = new MediaStream()
-  const tracks = data.tracks.map(track => {
-    const { media } = track
-    const mediaId = media === 'video' ? mainTransceiver : '1'
-    return {
-      ...track,
-      mediaId
-    }
-  })
+  const mainVideo = document.getElementById(mainTransceiver)
+  if (!mainVideo) {
+    const mediaStream = new MediaStream()
+    const tracks = data.tracks.map(track => {
+      const { media } = track
+      const mediaId = media === 'video' ? mainTransceiver : '1'
+      return {
+        ...track,
+        mediaId
+      }
+    })
 
-  transceiverToSourceIdMap[mainTransceiver] = data.sourceId 
-  sourcesTracks[data.sourceId] = tracks
-  
-  createVideoElement(mediaStream, mainTransceiver)
-  createVideoEventListener(mainTransceiver)
+    transceiverToSourceIdMap[mainTransceiver] = data.sourceId 
+    sourcesTracks[data.sourceId] = tracks
+    
+    createVideoElement(mediaStream, mainTransceiver)
+    createVideoEventListener(mainTransceiver)
+  } else {
+    mainVideo.hidden = false
+  }
 }
 
 const addStreamToVideoElement = (mediaStream, videoMediaId) => {
@@ -134,16 +139,20 @@ const unprojectAndRemoveVideo = async (sourceId) => {
   const videoMediaId = sourcesTracks[sourceId].find(track => track.media === 'video').mediaId
   const tracksMediaIds = sourcesTracks[sourceId].map(track => track.mediaId)
   const video = document.getElementById(videoMediaId)
-  
-  await viewer.unproject(tracksMediaIds)
 
-  if (videoMediaId === mainTransceiver) {
-    mainVideoContainer.removeChild(video)
+  if (sourceId) {
+    await viewer.unproject(tracksMediaIds)
+  
+    if (videoMediaId === mainTransceiver) {
+      mainVideoContainer.removeChild(video)
+    } else {
+      remoteVideosContainer.removeChild(video)
+    }
+    delete sourcesTracks[sourceId]
+    delete transceiverToSourceIdMap[videoMediaId]
   } else {
-    remoteVideosContainer.removeChild(video)
+    video.hidden = true
   }
-  delete sourcesTracks[sourceId]
-  delete transceiverToSourceIdMap[videoMediaId]
 }
 
 const sourcesDropDown = document.getElementById('sourcesDropDown')

--- a/packages/millicast-multiview-demo/src/multiviewer.js
+++ b/packages/millicast-multiview-demo/src/multiviewer.js
@@ -143,11 +143,7 @@ const unprojectAndRemoveVideo = async (sourceId) => {
   if (sourceId) {
     await viewer.unproject(tracksMediaIds)
   
-    if (videoMediaId === mainTransceiver) {
-      mainVideoContainer.removeChild(video)
-    } else {
-      remoteVideosContainer.removeChild(video)
-    }
+    remoteVideosContainer.removeChild(video)
     delete sourcesTracks[sourceId]
     delete transceiverToSourceIdMap[videoMediaId]
   } else {

--- a/packages/millicast-publisher-demo/src/publisher.js
+++ b/packages/millicast-publisher-demo/src/publisher.js
@@ -166,8 +166,9 @@ document.addEventListener("DOMContentLoaded", async (event) => {
         get: (searchParams, prop) => searchParams.get(prop),
       });
       let priority = parseInt(params.priority);
+      const sourceId = params.sourceId
       priority = isNaN(priority) ? undefined : priority;
-      await millicastPublishUserMedia.connect({ bandwidth, events: events, priority })
+      await millicastPublishUserMedia.connect({ bandwidth, events: events, priority, sourceId })
       isBroadcasting = true;
       broadcastHandler();
       setUserCount();

--- a/packages/millicast-sdk/package-lock.json
+++ b/packages/millicast-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@millicast/sdk",
-  "version": "0.1.45-RC2",
+  "version": "0.1.45-RC3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@millicast/sdk",
-      "version": "0.1.45-RC2",
+      "version": "0.1.45-RC3",
       "license": "See in LICENSE file",
       "dependencies": {
         "@dolbyio/webrtc-stats": "^0.4.0",

--- a/packages/millicast-sdk/package.json
+++ b/packages/millicast-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@millicast/sdk",
-  "version": "0.1.45-RC2",
+  "version": "0.1.45-RC3",
   "description": "SDK for building a realtime broadcaster using the Millicast platform.",
   "keywords": [
     "sdk",

--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -297,12 +297,22 @@ export default class Publish extends BaseWebRTC {
    * @param {String} [uuid="6e9cfd2a-5907-49ff-b363-8978a6e8340e"] String with UUID format as hex digit (XXXX-XX-XX-XX-XXXXXX).
    */
   sendMetadata (message, uuid = DOLBY_SEI_DATA_UUID) {
-    if (this.worker) {
+    if (this.worker && this.options.codec === VideoCodec.H264 && !this.options.disableVideo) {
       this.worker.postMessage({
         action: 'metadata-sei-user-data-unregistered',
         uuid: uuid,
         payload: message
       })
+    } else {
+      let warningMessage = 'Could not send metadata. Reason: '
+      if (this.options.codec !== VideoCodec.H264) {
+        warningMessage += 'Incompatible codec. Only H264 available.'
+      } else if (this.options.disableVideo) {
+        warningMessage += 'Video disabled.'
+      } else {
+        warningMessage += 'Unknown.'
+      }
+      logger.warn(warningMessage)
     }
   }
 };

--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -172,6 +172,7 @@ export default class Publish extends BaseWebRTC {
   stop () {
     super.stop()
     this.worker?.terminate()
+    this.worker = null
   }
 
   async initConnection (data) {

--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -238,6 +238,9 @@ export default class Publish extends BaseWebRTC {
 
     const workerBlob = new Blob([workerString])
     const workerURL = URL.createObjectURL(workerBlob)
+    if (this.worker) {
+      this.worker.terminate()
+    }
     this.worker = new Worker(workerURL)
 
     const senders = this.getRTCPeerConnection().getSenders()
@@ -304,13 +307,15 @@ export default class Publish extends BaseWebRTC {
         payload: message
       })
     } else {
-      let warningMessage = 'Could not send metadata. Reason: '
+      let warningMessage = 'Could not send metadata due to:'
       if (this.options.codec !== VideoCodec.H264) {
-        warningMessage += 'Incompatible codec. Only H264 available.'
-      } else if (this.options.disableVideo) {
-        warningMessage += 'Video disabled.'
-      } else {
-        warningMessage += 'Unknown.'
+        warningMessage += '\n- Incompatible codec. Only H264 available.'
+      }
+      if (this.options.disableVideo) {
+        warningMessage += '\n- Video disabled.'
+      }
+      if (!this.worker) {
+        warningMessage += '\n- Not publishing stream.'
       }
       logger.warn(warningMessage)
     }

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -250,7 +250,7 @@ export default class View extends BaseWebRTC {
         // eslint-disable-next-line no-undef
         trackEvent.receiver.transform = new RTCRtpScriptTransform(this.worker, {
           name: 'receiverTransform',
-          codecMap: this.codecPayloadTypeMap,
+          codecMap: { ...this.codecPayloadTypeMap },
           codec: this.options.codec,
           mid: trackEvent.transceiver?.mid
         })
@@ -258,7 +258,7 @@ export default class View extends BaseWebRTC {
         const { readable, writable } = trackEvent.receiver.createEncodedStreams()
         this.worker.postMessage({
           action: 'insertable-streams-receiver',
-          codecMap: this.codecPayloadTypeMap,
+          codecMap: { ...this.codecPayloadTypeMap },
           codec: this.options.codec,
           mid: trackEvent.transceiver?.mid,
           readable,

--- a/packages/millicast-sdk/src/workers/TransformWorker.worker.js
+++ b/packages/millicast-sdk/src/workers/TransformWorker.worker.js
@@ -38,7 +38,9 @@ function refreshSynchronizationSources (newSyncSource) {
   const now = new Date().getTime()
   synchronizationSources[newSyncSource] = now
 
-  const sourcesToDelete = Object.keys(synchronizationSources).map(source => now - synchronizationSources[source] > DROPPED_SOURCE_TIMEOUT)
+  const sourcesToDelete = Object.keys(synchronizationSources)
+    .filter(source => (now - synchronizationSources[source] > DROPPED_SOURCE_TIMEOUT))
+
   sourcesToDelete.forEach(source => {
     delete synchronizationSources[source]
     delete synchronizationSourcesWithMetadata[source]

--- a/packages/millicast-viewer-demo/src/viewer.js
+++ b/packages/millicast-viewer-demo/src/viewer.js
@@ -55,9 +55,6 @@ let playing = false;
 let fullBtn = document.querySelector("#fullBtn");
 let video = document.querySelector("video");
 
-video.addEventListener('loadedmetadata', (event) => {
-  Logger.log("loadedmetadata",event);
-});
 // MillicastView object
 let millicastView = null
 
@@ -136,37 +133,36 @@ const addStream = (stream) => {
 
     //If we already had a a stream
     if (video.srcObject) {
-       //Create temporal video element and switch streams when we have valid data
-       const tmp = video.cloneNode(true);
-       //Override the muted attribute with current muted state
-       tmp.muted = video.muted;
-       //Set same volume
-       tmp.volume = video.volume;
-       //Set new stream
-       tmp.srcObject = stream;
-       //Replicate playback state
-       if (video.playing) {
-          try { tmp.play(); } catch (e) {}
-        } else if (video.paused) {
-          try{ tmp.paused(); } catch (e) {}
-       }
-       //Replace the video when media has started playing              
-       tmp.addEventListener('loadedmetadata', (event) => {
-         Logger.log("loadedmetadata tmp",event);
-          video.parentNode.replaceChild(tmp, video);
-          //Pause previous video to avoid duplicated audio until the old PC is closed
-          try { video.pause(); } catch (e) {}
-          //If it was in full screen
-	  if (document.fullscreenElement == video) {
-            try { document.exitFullscreen(); tmp.requestFullscreen(); } catch(e) {}
-	  }
-          //If it was in picture in picture mode
-          if (document.pictureInPictureElement == video) {
-            try { document.exitPictureInPicture(); tmp.requestPictureInPicture(); } catch(e) {}
-          }
-          //Replace js objects too
-          video = tmp;
-       });
+      //Create temporal video element and switch streams when we have valid data
+      const tmp = video.cloneNode(true);
+      //Override the muted attribute with current muted state
+      tmp.muted = video.muted;
+      //Set same volume
+      tmp.volume = video.volume;
+      //Set new stream
+      tmp.srcObject = stream;
+      //Replicate playback state
+      if (video.playing) {
+        try { tmp.play(); } catch (e) {}
+      } else if (video.paused) {
+        try{ tmp.paused(); } catch (e) {}
+      }
+      //Replace the video when media has started playing              
+      tmp.addEventListener('loadedmetadata', (event) => {
+      video.parentNode.replaceChild(tmp, video);
+      //Pause previous video to avoid duplicated audio until the old PC is closed
+      try { video.pause(); } catch (e) {}
+      //If it was in full screen
+      if (document.fullscreenElement == video) {
+        try { document.exitFullscreen(); tmp.requestFullscreen(); } catch(e) {}
+      }
+      //If it was in picture in picture mode
+      if (document.pictureInPictureElement == video) {
+        try { document.exitPictureInPicture(); tmp.requestPictureInPicture(); } catch(e) {}
+      }
+      //Replace js objects too
+      video = tmp;
+      });
     } else {
        video.srcObject = stream;
     }


### PR DESCRIPTION
~Change `this.worker` variable for `this.workers` object in View js for handling multiple source streams. Each key correspond to its mid value.~
In order for the View instance to handle multiple source streams tracks (video and audio), every incoming track is used to create an encoded stream and passed it through the worker to process it. To maintain knowledge of which track is which, the transceiver's mid value is saved with the encoded stream created.

Additionally, add publisher demo `sourceId` query param for multisource publishing and expose `millicastView` in multiview demo