### PR TITLE
Add optional chaining operator to string method that can be undefined

### DIFF
--- a/packages/millicast-sdk/src/workers/TransformWorker.worker.js
+++ b/packages/millicast-sdk/src/workers/TransformWorker.worker.js
@@ -16,7 +16,7 @@ function createReceiverTransform (mid) {
     async transform (encodedFrame, controller) {
       // eslint-disable-next-line no-undef
       if (encodedFrame instanceof RTCEncodedVideoFrame) {
-        const frameCodec = payloadTypeCodec[encodedFrame.getMetadata().payloadType].toUpperCase() || codec.toUpperCase()
+        const frameCodec = payloadTypeCodec[encodedFrame.getMetadata().payloadType]?.toUpperCase() || codec?.toUpperCase()
         if (frameCodec === 'H264') {
           const metadata = extractH26xMetadata(encodedFrame, frameCodec)
           if (metadata.timecode || metadata.unregistered || metadata.seiPicTimingTimeCodeArray?.length > 0) {


### PR DESCRIPTION
In Safari, `payloadType` is undefined, so it needs a null-safe operator to avoid run time errors.

How to test it:

- Run `npm ci` in the root folder.
- Make sure to have the tokens and vars set in `.env` files.
- Run `npm run start` to run all packages.
- Publisher app will pop up in the browser (localhost:10001). Start to publish a stream.
- Open viewer app in Safari browser to start viewing the published stream. No error should pop up and audio/video should be seen/heard.