### PR TITLE
Only throw an info message for missing SPS

### DIFF
--- a/packages/millicast-sdk/src/utils/Codecs.js
+++ b/packages/millicast-sdk/src/utils/Codecs.js
@@ -339,7 +339,7 @@ function getSeiNalus (frameBuffer, codec) {
             spsState.findActiveSPS(removePreventionBytes(nalu.subarray(startCodeLength + headerLength)))
             shouldSearchActiveSPS = false
           } catch (err) {
-            console.warn('Failed to find active SPS. Will not be able to extract PIC timing metadata')
+            console.info('Failed to find active SPS. Will not be able to extract PIC timing metadata')
           }
           break
         default:


### PR DESCRIPTION
The application developer can't do anything with the warning, and it's confusing for them because 
- they don't know what triggered it
- we don't officially support SEI_PIC_TIMING