### PR TITLE
Make metadata optional. Not enabled by default

### DIFF
--- a/packages/millicast-publisher-demo/src/publisher.js
+++ b/packages/millicast-publisher-demo/src/publisher.js
@@ -158,8 +158,17 @@ document.addEventListener("DOMContentLoaded", async (event) => {
       });
       let priority = parseInt(params.priority);
       const sourceId = params.sourceId
-      priority = isNaN(priority) ? undefined : priority;
-      await millicastPublishUserMedia.connect({ bandwidth, events: events, priority, sourceId })
+      const metadata = params.metadata === "true"
+      const connectOptions = {
+        bandwidth,
+        events,
+        metadata
+      }
+      if (!isNaN(priority)) {
+        connectOptions.priority = priority
+      }
+      if (sourceId) connectOptions.sourceId = sourceId
+      await millicastPublishUserMedia.connect(connectOptions)
       isBroadcasting = true;
       broadcastHandler();
       setUserCount();

--- a/packages/millicast-publisher-demo/src/publisher.js
+++ b/packages/millicast-publisher-demo/src/publisher.js
@@ -156,7 +156,7 @@ document.addEventListener("DOMContentLoaded", async (event) => {
       const params = new Proxy(new URLSearchParams(window.location.search), {
         get: (searchParams, prop) => searchParams.get(prop),
       });
-      let priority = parseInt(params.priority);
+      const priority = parseInt(params.priority);
       const sourceId = params.sourceId
       const metadata = params.metadata === "true"
       const connectOptions = {

--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -16,13 +16,13 @@ const logger = Logger.get('Publish')
 const connectOptions = {
   mediaStream: null,
   bandwidth: 0,
+  metadata: false,
   disableVideo: false,
   disableAudio: false,
   codec: VideoCodec.H264,
   simulcast: false,
   scalabilityMode: null,
   peerConfig: {
-    encodedInsertableStreams: true,
     autoInitStats: true
   }
 }
@@ -62,6 +62,7 @@ export default class Publish extends BaseWebRTC {
    * @param {MediaStream|Array<MediaStreamTrack>} options.mediaStream - MediaStream to offer in a stream. This object must have
    * 1 audio track and 1 video track, or at least one of them. Alternative you can provide both tracks in an array.
    * @param {Number} [options.bandwidth = 0] - Broadcast bandwidth. 0 for unlimited.
+   * @param {Boolean} [options.metadata = false] - Enable metadata insertion if stream is compatible.
    * @param {Boolean} [options.disableVideo = false] - Disable the opportunity to send video stream.
    * @param {Boolean} [options.disableAudio = false] - Disable the opportunity to send audio stream.
    * @param {VideoCodec} [options.codec = 'h264'] - Codec for publish stream.
@@ -116,6 +117,7 @@ export default class Publish extends BaseWebRTC {
           joi.object()
         ),
       bandwidth: joi.number(),
+      metadata: joi.boolean(),
       disableVideo: joi.boolean(),
       disableAudio: joi.boolean(),
       codec: joi.string().valid(...Object.values(VideoCodec)),
@@ -129,6 +131,10 @@ export default class Publish extends BaseWebRTC {
     const { error, value } = schema.validate(options)
     if (error) logger.warn(error, value)
     this.options = { ...connectOptions, ...options, peerConfig: { ...connectOptions.peerConfig, ...options.peerConfig }, setSDPToPeer: false }
+    this.options.metadata =
+      this.options.metadata &&
+      this.options.codec === VideoCodec.H264 &&
+      !this.options.disableVideo
     await this.initConnection({ migrate: false })
   }
 
@@ -192,6 +198,9 @@ export default class Publish extends BaseWebRTC {
       publisherData = await this.tokenGenerator()
       //  Set the iceServers from the publish data into the peerConfig
       this.options.peerConfig.iceServers = publisherData?.iceServers
+      if (this.options.metadata) {
+        this.options.peerConfig.encodedInsertableStreams = supportsInsertableStreams
+      }
     } catch (error) {
       logger.error('Error generating token.')
       if (error instanceof FetchError) {
@@ -236,32 +245,33 @@ export default class Publish extends BaseWebRTC {
     promises = await Promise.all([getLocalSDPPromise, signalingConnectPromise])
     const localSdp = promises[0]
 
-    const workerBlob = new Blob([workerString])
-    const workerURL = URL.createObjectURL(workerBlob)
-    if (this.worker) {
-      this.worker.terminate()
-    }
-    this.worker = new Worker(workerURL)
-
-    const senders = this.getRTCPeerConnection().getSenders()
-
-    senders.forEach(sender => {
-      if (supportsRTCRtpScriptTransform) {
-        // eslint-disable-next-line no-undef
-        sender.transform = new RTCRtpScriptTransform(this.worker, {
-          name: 'senderTransform',
-          codec: this.options.codec
-        })
-      } else if (supportsInsertableStreams) {
-        const { readable, writable } = sender.createEncodedStreams()
-        this.worker.postMessage({
-          action: 'insertable-streams-sender',
-          codec: this.options.codec,
-          readable,
-          writable
-        }, [readable, writable])
+    if (this.options.metadata) {
+      const workerBlob = new Blob([workerString])
+      const workerURL = URL.createObjectURL(workerBlob)
+      if (!this.worker) {
+        this.worker = new Worker(workerURL)
       }
-    })
+
+      const senders = this.getRTCPeerConnection().getSenders()
+
+      senders.forEach(sender => {
+        if (supportsRTCRtpScriptTransform) {
+          // eslint-disable-next-line no-undef
+          sender.transform = new RTCRtpScriptTransform(this.worker, {
+            name: 'senderTransform',
+            codec: this.options.codec
+          })
+        } else if (supportsInsertableStreams) {
+          const { readable, writable } = sender.createEncodedStreams()
+          this.worker.postMessage({
+            action: 'insertable-streams-sender',
+            codec: this.options.codec,
+            readable,
+            writable
+          }, [readable, writable])
+        }
+      })
+    }
 
     let oldSignaling = this.signaling
     this.signaling = signalingInstance
@@ -300,7 +310,7 @@ export default class Publish extends BaseWebRTC {
    * @param {String} [uuid="6e9cfd2a-5907-49ff-b363-8978a6e8340e"] String with UUID format as hex digit (XXXX-XX-XX-XX-XXXXXX).
    */
   sendMetadata (message, uuid = DOLBY_SEI_DATA_UUID) {
-    if (this.worker && this.options.codec === VideoCodec.H264 && !this.options.disableVideo) {
+    if (this.options?.metadata && this.worker) {
       this.worker.postMessage({
         action: 'metadata-sei-user-data-unregistered',
         uuid: uuid,
@@ -308,14 +318,20 @@ export default class Publish extends BaseWebRTC {
       })
     } else {
       let warningMessage = 'Could not send metadata due to:'
-      if (this.options.codec !== VideoCodec.H264) {
-        warningMessage += '\n- Incompatible codec. Only H264 available.'
-      }
-      if (this.options.disableVideo) {
-        warningMessage += '\n- Video disabled.'
-      }
-      if (!this.worker) {
-        warningMessage += '\n- Not publishing stream.'
+      if (this.options) {
+        if (!this.options.metadata) {
+          warningMessage += '\n- Metadata option is not enabled.'
+          if (this.options.codec !== VideoCodec.H264) {
+            warningMessage += '\n- Incompatible codec. Only H264 available.'
+          }
+          if (this.options.disableVideo) {
+            warningMessage += '\n- Video disabled.'
+          }
+        } else if (!this.worker) {
+          warningMessage += '\n- Stream not being published.'
+        }
+      } else {
+        warningMessage += '\n- Stream not being published.'
       }
       logger.warn(warningMessage)
     }

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -12,6 +12,7 @@ import SdpParser from './utils/SdpParser'
 const logger = Logger.get('View')
 
 const connectOptions = {
+  metadata: false,
   disableVideo: false,
   disableAudio: false,
   peerConfig: {
@@ -65,6 +66,7 @@ export default class View extends BaseWebRTC {
    * @param {Object} [options]                          - General subscriber options.
    * @param {Boolean} [options.dtx = false]             - True to modify SDP for supporting dtx in opus. Otherwise False.
    * @param {Boolean} [options.absCaptureTime = false]  - True to modify SDP for supporting absolute capture time header extension. Otherwise False.
+   * @param {Boolean} [options.metadata = false]        - Enable metadata extraction if stream is compatible.
    * @param {Boolean} [options.disableVideo = false]    - Disable the opportunity to receive video stream.
    * @param {Boolean} [options.disableAudio = false]    - Disable the opportunity to receive audio stream.
    * @param {Number} [options.multiplexedAudioTracks]   - Number of audio tracks to recieve VAD multiplexed audio for secondary sources.
@@ -213,7 +215,9 @@ export default class View extends BaseWebRTC {
       subscriberData = await this.tokenGenerator()
       //  Set the iceServers from the subscribe data into the peerConfig
       this.options.peerConfig.iceServers = subscriberData?.iceServers
-      this.options.peerConfig.encodedInsertableStreams = supportsInsertableStreams
+      if (this.options.metadata) {
+        this.options.peerConfig.encodedInsertableStreams = supportsInsertableStreams
+      }
     } catch (error) {
       logger.error('Error generating token.')
       if (error instanceof FetchError) {
@@ -247,31 +251,36 @@ export default class View extends BaseWebRTC {
     this.stopReemitingWebRTCPeerInstanceEvents = reemit(webRTCPeerInstance, this, Object.values(webRTCEvents))
     this.stopReemitingSignalingInstanceEvents = reemit(signalingInstance, this, [signalingEvents.broadcastEvent])
 
-    const workerBlob = new Blob([workerString])
-    const workerURL = URL.createObjectURL(workerBlob)
-    this.worker = new Worker(workerURL)
-
-    webRTCPeerInstance.on('track', (trackEvent) => {
-      this.tracksMidValues[trackEvent.transceiver?.mid] = trackEvent.track
-      if (supportsRTCRtpScriptTransform) {
-        // eslint-disable-next-line no-undef
-        trackEvent.receiver.transform = new RTCRtpScriptTransform(this.worker, {
-          name: 'receiverTransform',
-          payloadTypeCodec: { ...this.payloadTypeCodec },
-          codec: this.options.codec,
-          mid: trackEvent.transceiver?.mid
-        })
-      } else if (supportsInsertableStreams) {
-        const { readable, writable } = trackEvent.receiver.createEncodedStreams()
-        this.worker.postMessage({
-          action: 'insertable-streams-receiver',
-          payloadTypeCodec: { ...this.payloadTypeCodec },
-          codec: this.options.codec,
-          mid: trackEvent.transceiver?.mid,
-          readable,
-          writable
-        }, [readable, writable])
+    if (this.options.metadata) {
+      const workerBlob = new Blob([workerString])
+      const workerURL = URL.createObjectURL(workerBlob)
+      if (!this.worker) {
+        this.worker = new Worker(workerURL)
       }
+
+      webRTCPeerInstance.on('track', (trackEvent) => {
+        this.tracksMidValues[trackEvent.transceiver?.mid] = trackEvent.track
+        if (supportsRTCRtpScriptTransform) {
+          // eslint-disable-next-line no-undef
+          trackEvent.receiver.transform = new RTCRtpScriptTransform(this.worker, {
+            name: 'receiverTransform',
+            payloadTypeCodec: { ...this.payloadTypeCodec },
+            codec: this.options.metadata && 'h264',
+            mid: trackEvent.transceiver?.mid
+          })
+        } else if (supportsInsertableStreams) {
+          const { readable, writable } = trackEvent.receiver.createEncodedStreams()
+          this.worker.postMessage({
+            action: 'insertable-streams-receiver',
+            payloadTypeCodec: { ...this.payloadTypeCodec },
+            codec: this.options.metadata && 'h264',
+            mid: trackEvent.transceiver?.mid,
+            readable,
+            writable
+          }, [readable, writable])
+        }
+      })
+
       this.worker.onmessage = (event) => {
         const decoder = new TextDecoder()
         const metadata = event.data.metadata
@@ -289,7 +298,7 @@ export default class View extends BaseWebRTC {
         }
         this.emit('onMetadata', metadata)
       }
-    })
+    }
 
     const getLocalSDPPromise = webRTCPeerInstance.getRTCLocalSDP({ ...this.options, stereo: true })
     const signalingConnectPromise = signalingInstance.connect()

--- a/packages/millicast-sdk/src/types/index.d.ts
+++ b/packages/millicast-sdk/src/types/index.d.ts
@@ -1072,6 +1072,10 @@ declare module '@millicast/sdk' {
      */
     absCaptureTime?: boolean;
     /**
+     * - Enable metadata extraction if stream is compatible.
+     */
+    metadata?: boolean;
+    /**
      * - Disable the opportunity to receive video stream.
      */
     disableVideo?: boolean;
@@ -1156,6 +1160,10 @@ declare module '@millicast/sdk' {
      * - Broadcast bandwidth. 0 for unlimited.
      */
     bandwidth?: number;
+    /**
+     * - Enable metadata insertion if stream is compatible.
+     */
+    metadata?: boolean;
     /**
      * - Disable the opportunity to send video stream.
      */

--- a/packages/millicast-viewer-demo/src/viewer.js
+++ b/packages/millicast-viewer-demo/src/viewer.js
@@ -21,6 +21,7 @@ const streamAccountId = !!href.searchParams.get("streamAccountId")
   ? href.searchParams.get("streamAccountId")
   : process.env.MILLICAST_ACCOUNT_ID;
 
+const metadata = href.searchParams.get("metadata") === "true";
 const disableVideo = href.searchParams.get("disableVideo") === "true";
 const disableAudio = href.searchParams.get("disableAudio") === "true";
 const muted =
@@ -190,8 +191,9 @@ const subscribe = async () => {
   try {
     isSubscribed = true
     const options = {
-      disableVideo: disableVideo,
-      disableAudio: disableAudio,
+      metadata,
+      disableVideo,
+      disableAudio,
       absCaptureTime: true,
     };
     window.millicastView = millicastView = newViewer()


### PR DESCRIPTION
Metadata is now optional on both sides, viewer and publisher. If connect option `metadata` is set to true, then `encodedInsertableStreams` peer config will be set and a Web Worker will be created only once. 

For Safari users, metadata extraction will be based only on this option, so if the stream published does not have H264 codec, but the viewer set metadata to true, it will try to extract. This replaces the `options.codec = 'h264'` needed previously, to avoid setting to options instead of only metadata one. We assume that if the user sets metadata extraction, is the same as setting the view codec to h264.