### PR TITLE
Release v0.1.46

### DIFF
--- a/packages/millicast-sdk/CHANGELOG.md
+++ b/packages/millicast-sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # @millicast/sdk
 
-## 0.1.45
+## 0.1.46
 
 ### Patch Changes
 
@@ -10,6 +10,7 @@
 - 5bd8ef5: Stats are now initialized by default. Logger.diagnose method changed to accept an object as parameter, with statsCount, historySize, minLogLevel, statsFormat.
 - faef94f: Deprecated the streamName argument in publish and view
 - 3bc547c: Added SEI user unregistered data extraction and insertion for H.264 codec.
+- 661f150: Added streamViewId variable in Signaling instance when subscribing to a stream.
 
 ## 0.1.44
 

--- a/packages/millicast-sdk/package-lock.json
+++ b/packages/millicast-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@millicast/sdk",
-  "version": "0.1.46-RC1",
+  "version": "0.1.46",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@millicast/sdk",
-      "version": "0.1.46-RC1",
+      "version": "0.1.46",
       "license": "See in LICENSE file",
       "dependencies": {
         "@dolbyio/webrtc-stats": "^0.4.0",

--- a/packages/millicast-sdk/package.json
+++ b/packages/millicast-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@millicast/sdk",
-  "version": "0.1.46-RC1",
+  "version": "0.1.46",
   "description": "SDK for building a realtime broadcaster using the Millicast platform.",
   "keywords": [
     "sdk",


### PR DESCRIPTION
## MillicastSDK v0.1.46
### Features
- With `sendMetadata()` you can publish metadata captured during broadcast and make it available at playback to synchronize events in your player with frame-level accuracy. 
- The `diagnose()` function can be used to troubleshoot the end-user quality of experience while gathering client analytics and important streaming metrics.
### Fixes
- You can now enable **simulcast** (both viewing and publishing) on all chromium-based browsers, including Edge. The codec limitation still applies, however. 
### Deprecations
- The `streamName` parameter in the Publish and Viewer class constructors has been marked as _deprecated_. The value supplied to the tokenGenerator object will be the one used by the SDK to connect to a stream. This will be removed in a future version of the SDK.
- There is no need to invoke `PeerConnection.initStats()` anymore, as it's now done automatically when `View.connect()`, `Publish.connect()` or `PeerConnection.createRTCPeer()`  is invoked.