### PR TITLE
Fix timecode insertion when UUID is not the default one

### DIFF
--- a/packages/millicast-sdk/src/utils/Codecs.js
+++ b/packages/millicast-sdk/src/utils/Codecs.js
@@ -570,7 +570,7 @@ export function extractH26xMetadata (encodedFrame, codec) {
 }
 
 function isValidUUID (uuid) {
-  const uuidRegEx = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/
+  const uuidRegEx = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
   return uuidRegEx.test(uuid)
 }
 
@@ -625,13 +625,12 @@ function createSEIMessageContentWithPrevensionBytes (content) {
 }
 
 function numberToByteArray (num) {
-  if (isNaN(num)) {
-    return
-  }
   const array = []
-  const bigint = BigInt(num)
-  for (let i = 0; i < Math.ceil(Math.floor(Math.log2(new Number(num)) + 1) / 8); i++) {
-    array.unshift(new Number((bigint >> BigInt(8 * i)) & 255n))
+  if (!isNaN(num)) {
+    const bigint = BigInt(num)
+    for (let i = 0; i < Math.ceil(Math.floor(Math.log2(new Number(num)) + 1) / 8); i++) {
+      array.unshift(new Number((bigint >> BigInt(8 * i)) & 255n))
+    }
   }
   return new Uint8Array(array)
 }

--- a/packages/millicast-sdk/src/workers/TransformWorker.worker.js
+++ b/packages/millicast-sdk/src/workers/TransformWorker.worker.js
@@ -1,4 +1,4 @@
-import { addH26xSEI, extractH26xMetadata } from '../utils/Codecs'
+import { DOLBY_SDK_TIMESTAMP_UUID, addH26xSEI, extractH26xMetadata } from '../utils/Codecs'
 
 const DROPPED_SOURCE_TIMEOUT = 2000
 const metadata = []
@@ -68,6 +68,9 @@ function createSenderTransform () {
             if (!/(h26[4])/.test(codec)) {
               throw new Error('Sending metadata is not supported with any other codec other than H.264')
             }
+            if (metadata[0].uuid === DOLBY_SDK_TIMESTAMP_UUID) {
+              metadata[0].timecode = Date.now()
+            }
             addH26xSEI(metadata[0], encodedFrame)
             synchronizationSourcesWithMetadata.push(newSyncSource)
           } catch (error) {
@@ -119,8 +122,7 @@ addEventListener('message', (event) => {
     case 'metadata-sei-user-data-unregistered':
       metadata.push({
         uuid: event.data.uuid,
-        payload: event.data.payload,
-        timecode: Date.now()
+        payload: event.data.payload
       })
       break
     default:


### PR DESCRIPTION
Timecode was been inserted every time despite UUID, and Viewer was only parsing it on default UUID, so content was failing to be parsed