### PR TITLE
Add timecode when UUID is invalid

### DIFF
--- a/packages/millicast-sdk/src/utils/Codecs.js
+++ b/packages/millicast-sdk/src/utils/Codecs.js
@@ -658,6 +658,7 @@ export function addH26xSEI ({ uuid, payload, timecode }, encodedFrame) {
   if (!isValidUUID(uuid)) {
     console.warn('Invalid UUID. Using default UUID.')
     uuid = DOLBY_SDK_TIMESTAMP_UUID
+    timecode = Date.now()
   }
   // Case of NALU H264 - User Unregistered Data
   const naluWithSEI = createSEINalu({ uuid, payload, timecode })


### PR DESCRIPTION
When UUID is invalid, default one is inserted, but timecode was not set, so the viewer side parsing was failing