### PR TITLE
Change error handling to prevent flow to be cut off

### DIFF
--- a/packages/millicast-sdk/src/utils/Codecs.js
+++ b/packages/millicast-sdk/src/utils/Codecs.js
@@ -440,7 +440,8 @@ function convertSEITimestamp (data) {
 
 function getSeiPicTimingTimecode (metadata, payloadContent) {
   if (!spsState.activeSPS) {
-    throw new Error('Cannot find the active SPS')
+    console.warn('Cannot find the active SPS')
+    return
   }
   const hrdParameters = spsState.activeSPS.vui_parameters.nal_hrd_parameters ?? spsState.activeSPS.vui_parameters.vcl_hrd_parameters
   const options = {


### PR DESCRIPTION
See DIOS-6050 for more info:
https://jira.dolby.net/jira/browse/DIOS-6050

This minor change fixes the bug we've been seeing in which SPS errors during metadata handling cause playback to fail.
We discovered this while working on the Bally's POC when trying to play ads triggered by RTS metadata. Currently the POC will crash on every 3rd refresh or so.