### PR TITLE
Stats : Change bytes to bits per second. 

### DIFF
--- a/.changeset/quiet-geckos-decide.md
+++ b/.changeset/quiet-geckos-decide.md
@@ -1,0 +1,5 @@
+---
+"@millicast/sdk": patch
+---
+
+The webrtc-stats lib reported bitrate in Bytes per second instead of bits, it's now fixed to be bits per second

--- a/packages/millicast-sdk/src/PeerConnectionStats.js
+++ b/packages/millicast-sdk/src/PeerConnectionStats.js
@@ -92,26 +92,30 @@ const parseWebRTCStats = (webRTCStats) => {
   const statsObject = {
     ...filteredStats,
     audio: {
-      inbounds: webRTCStats.input.audio.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, ...rest }) => ({
+      inbounds: webRTCStats.input.audio.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, bitrate, ...rest }) => ({
         packetsLostRatioPerSecond,
         packetsLostDeltaPerSecond,
+        bitrate: bitrate * 8,
         ...rest
       })),
-      outbounds: webRTCStats.output.audio.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, ...rest }) => ({
+      outbounds: webRTCStats.output.audio.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, bitrate, ...rest }) => ({
         packetsLostRatioPerSecond,
         packetsLostDeltaPerSecond,
+        bitrate: bitrate * 8,
         ...rest
       }))
     },
     video: {
-      inbounds: webRTCStats.input.video.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, ...rest }) => ({
+      inbounds: webRTCStats.input.video.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, bitrate, ...rest }) => ({
         packetsLostRatioPerSecond,
         packetsLostDeltaPerSecond,
+        bitrate: bitrate * 8,
         ...rest
       })),
-      outbounds: webRTCStats.output.video.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, ...rest }) => ({
+      outbounds: webRTCStats.output.video.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, bitrate, ...rest }) => ({
         packetsLostRatioPerSecond,
         packetsLostDeltaPerSecond,
+        bitrate: bitrate * 8,
         ...rest
       }))
     },


### PR DESCRIPTION
The web-rtc stats lib reported bytes per second instead of bits per second. We are now converting that back to bits per second. 