### PR TITLE
Convert bitrate to bps

### DIFF
--- a/.changeset/loud-drinks-complain.md
+++ b/.changeset/loud-drinks-complain.md
@@ -2,4 +2,4 @@
 "@millicast/sdk": patch
 ---
 
-Fix bitrate unit. Now showing correctly bits per second.
+Added bitrateBitsPerSecond stats attribute. Now bitrate attribute is shown in Bytes per second and bitrateBitsPerSecond in bits per second.

--- a/.changeset/loud-drinks-complain.md
+++ b/.changeset/loud-drinks-complain.md
@@ -1,0 +1,5 @@
+---
+"@millicast/sdk": patch
+---
+
+Fix bitrate unit. Now showing correctly bits per second.

--- a/packages/millicast-sdk/src/PeerConnectionStats.js
+++ b/packages/millicast-sdk/src/PeerConnectionStats.js
@@ -46,7 +46,8 @@ const logger = Logger.get('PeerConnectionStats')
  * @property {Number} totalPacketsLost - Total packets lost.
  * @property {Number} packetsLostRatioPerSecond - Total packet lost ratio per second.
  * @property {Number} packetsLostDeltaPerSecond - Total packet lost delta per second.
- * @property {Number} bitrate - Current bitrate in bits per second.
+ * @property {Number} bitrate - Current bitrate in Bytes per second.
+ * @property {Number} bitrateBitsPerSecond - Current bitrate in bits per second.
  * @property {Number} packetRate - The rate at which packets are being received, measured in packets per second.
  * @property {Number} jitterBufferDelay - Total delay in seconds currently experienced by the jitter buffer.
  * @property {Number} jitterBufferEmittedCount - Total number of packets emitted from the jitter buffer.
@@ -62,7 +63,8 @@ const logger = Logger.get('PeerConnectionStats')
  * @property {String} [qualityLimitationReason] - If it's video report, indicate the reason why the media quality in the stream is currently being reduced by the codec during encoding, or none if no quality reduction is being performed.
  * @property {Number} timestamp - Timestamp of report.
  * @property {Number} totalBytesSent - Total bytes sent indicates the total number of payload bytes that hve been sent so far on the connection described by the candidate pair.
- * @property {Number} bitrate - Current bitrate in bits per second.
+ * @property {Number} bitrate - Current bitrate in Bytes per second.
+ * @property {Number} bitrateBitsPerSecond - Current bitrate in bits per second.
  * @property {Number} bytesSentDelta - Change in the number of bytes sent since the last report.
  * @property {Number} totalPacketsSent - Total number of packets sent.
  * @property {Number} packetsSentDelta - Change in the number of packets sent since the last report.
@@ -107,13 +109,15 @@ const parseWebRTCStats = (webRTCStats) => {
       inbounds: webRTCStats.input.video.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, bitrate, ...rest }) => ({
         packetsLostRatioPerSecond,
         packetsLostDeltaPerSecond,
-        bitrate: bitrate * 8,
+        bitrateBitsPerSecond: bitrate * 8,
+        bitrate,
         ...rest
       })),
       outbounds: webRTCStats.output.video.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, bitrate, ...rest }) => ({
         packetsLostRatioPerSecond,
         packetsLostDeltaPerSecond,
-        bitrate: bitrate * 8,
+        bitrateBitsPerSecond: bitrate * 8,
+        bitrate,
         ...rest
       }))
     },

--- a/packages/millicast-sdk/src/PeerConnectionStats.js
+++ b/packages/millicast-sdk/src/PeerConnectionStats.js
@@ -104,14 +104,16 @@ const parseWebRTCStats = (webRTCStats) => {
       }))
     },
     video: {
-      inbounds: webRTCStats.input.video.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, ...rest }) => ({
+      inbounds: webRTCStats.input.video.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, bitrate, ...rest }) => ({
         packetsLostRatioPerSecond,
         packetsLostDeltaPerSecond,
+        bitrate: bitrate * 8,
         ...rest
       })),
-      outbounds: webRTCStats.output.video.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, ...rest }) => ({
+      outbounds: webRTCStats.output.video.map(({ packetLossRatio: packetsLostRatioPerSecond, packetLossDelta: packetsLostDeltaPerSecond, bitrate, ...rest }) => ({
         packetsLostRatioPerSecond,
         packetsLostDeltaPerSecond,
+        bitrate: bitrate * 8,
         ...rest
       }))
     },

--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -312,7 +312,7 @@ export default class Publish extends BaseWebRTC {
     if (this.options?.metadata && this.worker) {
       this.worker.postMessage({
         action: 'metadata-sei-user-data-unregistered',
-        uuid: uuid,
+        uuid,
         payload: message
       })
     } else {

--- a/packages/millicast-sdk/src/types/index.d.ts
+++ b/packages/millicast-sdk/src/types/index.d.ts
@@ -376,7 +376,6 @@ declare module '@millicast/sdk' {
      * - Current frame width if it's video report.
      */
     frameWidth?: number;
-
     /**
      * - Total number of key frames that have been decoded if it's video report.
      */
@@ -418,15 +417,17 @@ declare module '@millicast/sdk' {
      */
     packetsLostDeltaPerSecond: number;
     /**
-     * - Current bitrate in bits per second.
+     * - Current bitrate in Bytes per second.
      */
     bitrate: number;
-
+    /**
+     * - Current bitrate in bits per second.
+     */
+    bitrateBitsPerSecond: number;
     /**
      * - Total delay in seconds currently experienced by the jitter buffer.
      */
     jitterBufferDelay : number;
-
     /**
      * - Total number of packets emitted from the jitter buffer.
      */
@@ -467,15 +468,17 @@ declare module '@millicast/sdk' {
      */
     totalBytesSent: number;
     /**
-     * - Current bitrate in bits per second.
+     * - Current bitrate in Bytes per second.
      */
     bitrate: number;
-
+    /**
+     * - Current bitrate in bits per second.
+     */
+    bitrateBitsPerSecond: number;
     /**
      *  - Change in the number of bytes sent since the last report.
      */
     bytesSentDelta: number;
-
     /**
      *  - Total number of packets sent.
      */
@@ -496,7 +499,6 @@ declare module '@millicast/sdk' {
      * - Total number of retransmitted packets sent.
      */
     retransmittedPacketsSent: number; 
-
     /**
      * - Change in the number of retransmitted packets sent since the last report.
      */
@@ -518,7 +520,6 @@ declare module '@millicast/sdk' {
      * 
      */  
     [qualityLimitationDurations] : Date
-
   };
 
   class PeerConnectionStats extends events.EventEmitter {

--- a/packages/millicast-sdk/src/utils/Diagnostics.js
+++ b/packages/millicast-sdk/src/utils/Diagnostics.js
@@ -20,7 +20,7 @@ function transformWebRTCStatsToCMCD (diagnostics) {
       ts: Math.round(stat.timestamp) || '', // Timestamp to the nearest millisecond
       ot: type === 'audio' ? 'a' : 'v', // 'a' for audio, 'v' for video
       bl: stat.jitterBufferDelay || 0, // Buffer length from jitterBufferDelay, default to 0 if not available
-      br: Math.round(stat.bitrate || 0), // Bitrate, rounded to nearest integer, default to 0 if not available
+      br: Math.round(stat.bitrateBitsPerSecond || 0), // Bitrate, rounded to nearest integer, default to 0 if not available
       pld: stat.packetsLostDeltaPerSecond || 0, // Packets lost delta per second, default to 0 if not available
       j: stat.jitter || 0, // Jitter, default to 0 if not available
       mtp: stat.packetRate || 0, // Measured throughput, approximated by packet rate, default to 0 if not available

--- a/packages/millicast-sdk/tests/e2e/PublishTest.js
+++ b/packages/millicast-sdk/tests/e2e/PublishTest.js
@@ -72,7 +72,7 @@ class MillicastPublishTest {
     try {
       const broadcastOptions = options ?? {
         mediaStream: this.mediaStream,
-        bandwidth: bandwidth,
+        bandwidth,
         disableVideo: false,
         disableAudio: false,
         simulcast: this.selectedCodec === 'h264' || this.selectedCodec === 'vp8' ? this.simulcast : false,
@@ -226,7 +226,7 @@ class MillicastPublishTest {
           <td>${track.qualityLimitationReason}</td>
           <td>${track.framesPerSecond || '-'}</td>
           <td>${track.totalBytesSent}</td>
-          <td>${track.bitrate / 1000}</td>
+          <td>${track.bitrateBitsPerSecond / 1000}</td>
           <td>${new Date(track.timestamp).toISOString()}</td>
         </tr>
       `)
@@ -243,7 +243,7 @@ class MillicastPublishTest {
           <td>-</td>
           <td>-</td>
           <td>${track.totalBytesSent}</td>
-          <td>${track.bitrate / 1000}</td>
+          <td>${track.bitrateBitsPerSecond / 1000}</td>
           <td>${new Date(track.timestamp).toISOString()}</td>
         </tr>
       `)

--- a/packages/millicast-sdk/tests/e2e/ViewTest.js
+++ b/packages/millicast-sdk/tests/e2e/ViewTest.js
@@ -99,7 +99,7 @@ class MillicastViewTest {
           <td>${track.packetsLostRatioPerSecond}</td>
           <td>${track.totalPacketsLost}</td>
           <td>${track.jitter}</td>
-          <td>${track.bitrate / 1000}</td>
+          <td>${track.bitrateBitsPerSecond / 1000}</td>
           <td>${new Date(track.timestamp).toISOString()}</td>
         </tr>
       `)
@@ -118,7 +118,7 @@ class MillicastViewTest {
           <td>${track.packetsLostRatioPerSecond}</td>
           <td>${track.totalPacketsLost}</td>
           <td>${track.jitter}</td>
-          <td>${track.bitrate / 1000}</td>
+          <td>${track.bitrateBitsPerSecond / 1000}</td>
           <td>${new Date(track.timestamp).toISOString()}</td>
         </tr>
       `)

--- a/packages/millicast-sdk/tests/unit/LoggerDiagnose.steps.js
+++ b/packages/millicast-sdk/tests/unit/LoggerDiagnose.steps.js
@@ -25,7 +25,7 @@ const expectedObject = {
   streamName: expect.any(String),
   subscriberId: expect.any(String),
   connection: expect.any(String),
-  version: version,
+  version,
   timestamp: expect.any(String),
   userAgent: expect.any(String),
   stats: expect.any(Array)

--- a/packages/millicast-sdk/tests/unit/ManageSignaling.steps.js
+++ b/packages/millicast-sdk/tests/unit/ManageSignaling.steps.js
@@ -17,7 +17,7 @@ defineFeature(feature, test => {
   beforeEach(async () => {
     server = new WS(publishWebSocketLocation, { jsonProtocol: true })
     signaling = new Signaling({
-      streamName: streamName,
+      streamName,
       url: publishWebSocketLocation
     })
   })
@@ -64,7 +64,7 @@ defineFeature(feature, test => {
     when('I want to connect to no responding server', async () => {
       server.on('connection', () => server.error())
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       signaling.on('wsConnectionError', handler)

--- a/packages/millicast-sdk/tests/unit/OfferPublishingStream.steps.js
+++ b/packages/millicast-sdk/tests/unit/OfferPublishingStream.steps.js
@@ -99,7 +99,7 @@ defineFeature(feature, test => {
 
     when('I offer my local sdp with h264 codec and recording option', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       response = await signaling.publish(localSdp, 'h264', true)
@@ -118,7 +118,7 @@ defineFeature(feature, test => {
 
     given('a local sdp and a previous active connection to server', async () => {
       signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       await signaling.connect()
@@ -154,7 +154,7 @@ defineFeature(feature, test => {
 
     when('I offer a null sdp', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       try {
@@ -177,7 +177,7 @@ defineFeature(feature, test => {
 
     given('I have previous connection to server', async () => {
       signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       await signaling.connect()
@@ -265,7 +265,7 @@ defineFeature(feature, test => {
 
     when('I offer a sdp with invalid codec', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       try {
@@ -298,7 +298,7 @@ defineFeature(feature, test => {
 
     when('I offer my local sdp with vp8 codec', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       response = await signaling.publish(localSdp, 'vp8')
@@ -328,7 +328,7 @@ defineFeature(feature, test => {
 
     when('I offer my local sdp with vp9 codec', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       response = await signaling.publish(localSdp, 'vp9')
@@ -358,7 +358,7 @@ defineFeature(feature, test => {
 
     when('I offer my local sdp with av1 codec', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       response = await signaling.publish(localSdp, 'av1')
@@ -389,7 +389,7 @@ defineFeature(feature, test => {
 
     when('I offer my local sdp with av1 codec', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       response = await signaling.publish(localSdp, 'av1')
@@ -420,7 +420,7 @@ defineFeature(feature, test => {
 
     when('I offer my local sdp with av1 codec', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       response = await signaling.publish(localSdp, 'av1')
@@ -450,7 +450,7 @@ defineFeature(feature, test => {
 
     when('I offer my local sdp using options object', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       const signalingPublishOptions = {
@@ -483,7 +483,7 @@ defineFeature(feature, test => {
 
     when('I offer a sdp', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       response = await signaling.publish(localSdp)
@@ -512,7 +512,7 @@ defineFeature(feature, test => {
 
     when('I offer my local sdp and I set the events active and inactive as events that i want to get', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       const signalingPublishOptions = {

--- a/packages/millicast-sdk/tests/unit/OfferSubscribingStream.steps.js
+++ b/packages/millicast-sdk/tests/unit/OfferSubscribingStream.steps.js
@@ -102,7 +102,7 @@ defineFeature(feature, test => {
 
     when('I offer my local sdp', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       response = await signaling.subscribe(localSdp)
@@ -154,7 +154,7 @@ defineFeature(feature, test => {
 
     when('I offer my local sdp', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       response = await signaling.subscribe(localSdp)
@@ -205,7 +205,7 @@ defineFeature(feature, test => {
 
     when('I offer my local sdp using options object', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       const signalingSubscribeOptions = {
@@ -248,7 +248,7 @@ defineFeature(feature, test => {
         a=rtcp-fb:123 nack pli
       `
       signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       await signaling.connect()
@@ -284,7 +284,7 @@ defineFeature(feature, test => {
 
     when('I offer a null sdp', async () => {
       const signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       try {
@@ -308,7 +308,7 @@ defineFeature(feature, test => {
 
     given('I have previous connection to server', async () => {
       signaling = new Signaling({
-        streamName: streamName,
+        streamName,
         url: publishWebSocketLocation
       })
       await signaling.connect()


### PR DESCRIPTION
Webrtc stats library has `bitrate` attribute in Bytes per second while the SDK delivered it in bits per second, so we only need to multiply those incoming values times 8 to convert them into bps.