### PR TITLE
Initialize worker on drm track to avoid error thrown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41174,7 +41174,7 @@
     },
     "packages/millicast-sdk": {
       "name": "@millicast/sdk",
-      "version": "0.3.0-RC-4",
+      "version": "0.3.0-RC-5",
       "license": "See in LICENSE file",
       "dependencies": {
         "@dolbyio/webrtc-stats": "^1.0.2",

--- a/packages/millicast-sdk/package-lock.json
+++ b/packages/millicast-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@millicast/sdk",
-  "version": "0.3.0-RC-3",
+  "version": "0.3.0-RC-5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@millicast/sdk",
-      "version": "0.3.0-RC-3",
+      "version": "0.3.0-RC-5",
       "license": "See in LICENSE file",
       "dependencies": {
         "@dolbyio/webrtc-stats": "^0.4.0",

--- a/packages/millicast-sdk/package.json
+++ b/packages/millicast-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@millicast/sdk",
-  "version": "0.3.0-RC-4",
+  "version": "0.3.0-RC-5",
   "description": "SDK for building a realtime broadcaster using the Millicast platform.",
   "keywords": [
     "sdk",

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -326,7 +326,10 @@ export default class View extends BaseWebRTC {
           logger.error('Failed to apply DRM on media Id:', mediaId, 'error is: ', error)
           this.emit('error', new Error('Failed to apply DRM on media Id: ' + mediaId + ' error is: ' + error))
         }
-        this.worker?.addEventListener('message', (message) => {
+        if (!this.worker) {
+          this.worker = new TransformWorker()
+        }
+        this.worker.addEventListener('message', (message) => {
           if (message.data.event === 'complete') {
             // feed the frame to DRM processing worker
             rtcDrmFeedFrame(message.data.frame, null, drmOptions)

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -326,7 +326,7 @@ export default class View extends BaseWebRTC {
           logger.error('Failed to apply DRM on media Id:', mediaId, 'error is: ', error)
           this.emit('error', new Error('Failed to apply DRM on media Id: ' + mediaId + ' error is: ' + error))
         }
-        this.worker.addEventListener('message', (message) => {
+        this.worker?.addEventListener('message', (message) => {
           if (message.data.event === 'complete') {
             // feed the frame to DRM processing worker
             rtcDrmFeedFrame(message.data.frame, null, drmOptions)


### PR DESCRIPTION
~On the viewer side, using the SDK, sometimes the addEventListener of the worker throws an error because the worker was not initialized before. Added a guard to avoid this error~

**Edit:** The worker was not being initialized if metadata option was not passed. Added an initialization of the worker if it does not exist before the event listener failing.