### PR TITLE
Fix for subscriber token not set in getSubscriber's response

### DIFF
--- a/packages/millicast-sdk/src/Director.js
+++ b/packages/millicast-sdk/src/Director.js
@@ -204,7 +204,7 @@ const Director = {
       }
       data = parseIncomingDirectorResponse(data)
       logger.debug('Getting subscriber response: ', data)
-      if (subscriberToken) data.data.subscriberToken = subscriberToken
+      if (optionsParsed.subscriberToken) data.data.subscriberToken = optionsParsed.subscriberToken
       return data.data
     } catch (e) {
       logger.error('Error while getting subscriber connection path. ', e)


### PR DESCRIPTION
Subscriber token is not set in getSubscriber's response when getSubscriber args are passed as an object.