### PR TITLE
Call subscribe again when there is no cached DRM profile

### DIFF
--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -246,10 +246,6 @@ export default class View extends BaseWebRTC {
       streamName: this.streamName,
       url: `${subscriberData.urls[0]}?token=${subscriberData.jwt}`
     })
-    if (subscriberData.drmObject) {
-      // cache the DRM license server URLs
-      this.DRMProfile = subscriberData.drmObject
-    }
     if (subscriberData.subscriberToken) {
       this.subscriberToken = subscriberData.subscriberToken
     }
@@ -258,10 +254,8 @@ export default class View extends BaseWebRTC {
     await webRTCPeerInstance.createRTCPeer(this.options.peerConfig)
     // Stop emiting events from the previous instances
     this.stopReemitingWebRTCPeerInstanceEvents?.()
-    // this.stopReemitingSignalingInstanceEvents?.()
     // And start emitting from the new ones
     this.stopReemitingWebRTCPeerInstanceEvents = reemit(webRTCPeerInstance, this, Object.values(webRTCEvents).filter(e => e !== webRTCEvents.track))
-    // this.stopReemitingSignalingInstanceEvents = reemit(signalingInstance, this, [signalingEvents.broadcastEvent])
 
     if (this.options.metadata) {
       if (!this.worker) {
@@ -317,11 +311,14 @@ export default class View extends BaseWebRTC {
                 this.DRMProfile = subscriberData.drmObject
               }
             }
+            this.emit(signalingEvents.broadcastEvent, event)
             this.isMainStreamActive = true
-            while (this.eventQueue.length > 0) {
-              this.onTrackEvent(this.eventQueue.shift())
+            if (event.name === 'active') {
+              while (this.eventQueue.length > 0) {
+                this.onTrackEvent(this.eventQueue.shift())
+              }
             }
-            break
+            return
           case 'inactive':
             this.isMainStreamActive = false
             break

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -313,10 +313,8 @@ export default class View extends BaseWebRTC {
             }
             this.emit(signalingEvents.broadcastEvent, event)
             this.isMainStreamActive = true
-            if (event.name === 'active') {
-              while (this.eventQueue.length > 0) {
-                this.onTrackEvent(this.eventQueue.shift())
-              }
+            while (this.eventQueue.length > 0) {
+              this.onTrackEvent(this.eventQueue.shift())
             }
             return
           case 'inactive':

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -258,10 +258,10 @@ export default class View extends BaseWebRTC {
     await webRTCPeerInstance.createRTCPeer(this.options.peerConfig)
     // Stop emiting events from the previous instances
     this.stopReemitingWebRTCPeerInstanceEvents?.()
-    this.stopReemitingSignalingInstanceEvents?.()
+    // this.stopReemitingSignalingInstanceEvents?.()
     // And start emitting from the new ones
     this.stopReemitingWebRTCPeerInstanceEvents = reemit(webRTCPeerInstance, this, Object.values(webRTCEvents).filter(e => e !== webRTCEvents.track))
-    this.stopReemitingSignalingInstanceEvents = reemit(signalingInstance, this, [signalingEvents.broadcastEvent])
+    // this.stopReemitingSignalingInstanceEvents = reemit(signalingInstance, this, [signalingEvents.broadcastEvent])
 
     if (this.options.metadata) {
       if (!this.worker) {
@@ -306,10 +306,17 @@ export default class View extends BaseWebRTC {
       this.onTrackEvent(trackEvent)
     })
 
-    signalingInstance.on(signalingEvents.broadcastEvent, (event) => {
+    signalingInstance.on(signalingEvents.broadcastEvent, async (event) => {
       if (event.data.sourceId === null) {
         switch (event.name) {
           case 'active':
+            if (this.DRMProfile == null) {
+              const subscriberData = await this.tokenGenerator()
+              if (subscriberData.drmObject) {
+                // cache the DRM license server URLs
+                this.DRMProfile = subscriberData.drmObject
+              }
+            }
             this.isMainStreamActive = true
             while (this.eventQueue.length > 0) {
               this.onTrackEvent(this.eventQueue.shift())
@@ -321,6 +328,7 @@ export default class View extends BaseWebRTC {
           default:
             break
         }
+        this.emit(signalingEvents.broadcastEvent, event)
       }
     })
 

--- a/packages/millicast-viewer-demo/src/viewer.js
+++ b/packages/millicast-viewer-demo/src/viewer.js
@@ -86,7 +86,7 @@ const newViewer = () => {
     }
   });
   millicastView.on("track", (event) => {
-    if (!millicastView.isDRMOn) addStream(event.streams[0]);
+    if (!enableDRM) addStream(event.streams[0]);
   });
 
   millicastView.on('metadata', (metadata) => {


### PR DESCRIPTION
We need to reproduce the issue when open viewer before broadcast start, the first 'subscrbe' API returned 200 response without DRM profile, when 'active' event comes we need to invoke 'subscdribe' API again.

But I cannot reproduce that case, since the 'subscribe' API always return 400 now.