### PR TITLE
Update @dolbyio/webrtc-stats to version 1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2158,9 +2158,10 @@
       }
     },
     "node_modules/@dolbyio/webrtc-stats": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@dolbyio/webrtc-stats/-/webrtc-stats-1.0.2.tgz",
-      "integrity": "sha512-hpXUbtJl+yQOGBACWFfFsYFJrBbY8N+pdo5CHQVVKm4CvGaFai6gfW/ged0Hce9G/CvnF2HcZ54jhsnyMYwx4A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@dolbyio/webrtc-stats/-/webrtc-stats-1.0.4.tgz",
+      "integrity": "sha512-QOo1TVQSI3NVaSWG1p3JopLkTDB9z94t9Bi1JvJwaQbwrEkLwGXccOX9U+FjroUsfSh9QK2tlifKJifedEBa7w==",
+      "license": "MIT",
       "dependencies": {
         "js-logger": "^1.6.1"
       }
@@ -41641,7 +41642,7 @@
       "version": "0.3.3-RC-1",
       "license": "See in LICENSE file",
       "dependencies": {
-        "@dolbyio/webrtc-stats": "^1.0.2",
+        "@dolbyio/webrtc-stats": "^1.0.4",
         "@types/node": "^18.11.10",
         "Base64": "^1.1.0",
         "buffer": "^6.0.3",

--- a/packages/millicast-sdk/package.json
+++ b/packages/millicast-sdk/package.json
@@ -53,7 +53,7 @@
     "url": "git+https://github.com/millicast/millicast-sdk.git"
   },
   "dependencies": {
-    "@dolbyio/webrtc-stats": "^1.0.2",
+    "@dolbyio/webrtc-stats": "^1.0.4",
     "@types/node": "^18.11.10",
     "Base64": "^1.1.0",
     "buffer": "^6.0.3",


### PR DESCRIPTION
Update @dolbyio/webrtc-stats to version [1.0.4](https://github.com/DolbyIO/web-webrtc-stats/releases/tag/1.0.4)