### PR TITLE
Add stats configuration object to connect functions

### DIFF
--- a/packages/millicast-sdk/src/Publish.js
+++ b/packages/millicast-sdk/src/Publish.js
@@ -72,7 +72,7 @@ export default class Publish extends BaseWebRTC {
    * @param {Boolean} [options.simulcast = false] - Enable simulcast. **Only available in Chromium based browsers and with H.264 or VP8 video codecs.**
    * @param {String} [options.scalabilityMode = null] - Selected scalability mode. You can get the available capabilities using <a href="PeerConnection#.getCapabilities">PeerConnection.getCapabilities</a> method.
    * **Only available in Google Chrome.**
-   * @param {RTCConfiguration} [options.peerConfig = null] - Options to configure the new RTCPeerConnection.
+   * @param {PeerConnectionConfig} [options.peerConfig = null] - Options to configure the new RTCPeerConnection.
    * @param {Boolean} [options.record = false ] - Enable stream recording. If record is not provided, use default Token configuration. **Only available in Tokens with recording enabled.**
    * @param {Array<String>} [options.events = null] - Specify which events will be delivered by the server (any of "active" | "inactive" | "viewercount").*
    * @param {Number} [options.priority = null] - When multiple ingest streams are provided by the customer, add the ability to specify a priority between all ingest streams. Decimal integer between the range [-2^31, +2^31 - 1]. For more information, visit [our documentation](https://docs.dolby.io/streaming-apis/docs/backup-publishing).

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -74,26 +74,32 @@ export default class View extends BaseWebRTC {
    */
 
   /**
+   * @typedef {RTCConfiguration} PeerConnectionConfig - RTC Peer Connection Configuration object. Extends `RTCConfiguration`.
+   * @property {Boolean} [autoInitStats = true]  - Whether stats collection should be auto initialized.
+   * @property {Number} [statsIntervalMs = 1000] - The interval, in milliseconds, at which we poll stats.
+   */
+
+  /**
    * Connects to an active stream as subscriber.
    *
    * In the example, `addStreamToYourVideoTag` and `getYourSubscriberConnectionPath` is your own implementation.
-   * @param {Object} [options]                          - General subscriber options.
-   * @param {Boolean} [options.dtx = false]             - True to modify SDP for supporting dtx in opus. Otherwise False.
-   * @param {Boolean} [options.absCaptureTime = false]  - True to modify SDP for supporting absolute capture time header extension. Otherwise False.
-   * @param {Boolean} [options.metadata = false]        - Enable metadata extraction if stream is compatible.
-   * @param {Boolean} [options.drm = false]             - Enable the DRM protected stream playback.
-   * @param {Boolean} [options.disableVideo = false]    - Disable the opportunity to receive video stream.
-   * @param {Boolean} [options.disableAudio = false]    - Disable the opportunity to receive audio stream.
-   * @param {Number} [options.multiplexedAudioTracks]   - Number of audio tracks to recieve VAD multiplexed audio for secondary sources.
-   * @param {String} [options.pinnedSourceId]           - Id of the main source that will be received by the default MediaStream.
-   * @param {Array<String>} [options.excludedSourceIds] - Do not receive media from the these source ids.
-   * @param {Array<String>} [options.events]            - Override which events will be delivered by the server (any of "active" | "inactive" | "vad" | "layers" | "viewercount" | "updated").*
-   * @param {RTCConfiguration} [options.peerConfig]     - Options to configure the new RTCPeerConnection.
-   * @param {LayerInfo} [options.layer]                 - Select the simulcast encoding layer and svc layers for the main video track, leave empty for automatic layer selection based on bandwidth estimation.
-   * @param {Object} [options.forcePlayoutDelay = false]- Ask the server to use the playout delay header extension.
-   * @param {Number} [options.forcePlayoutDelay.min]    - Set minimum playout delay value.
-   * @param {Number} [options.forcePlayoutDelay.max]    - Set maximum playout delay value.
-   * @param {Boolean} [options.enableDRM]               - Enable DRM, default is false.
+   * @param {Object} [options]                                  - General subscriber options.
+   * @param {Boolean} [options.dtx = false]                     - True to modify SDP for supporting dtx in opus. Otherwise False.
+   * @param {Boolean} [options.absCaptureTime = false]          - True to modify SDP for supporting absolute capture time header extension. Otherwise False.
+   * @param {Boolean} [options.metadata = false]                - Enable metadata extraction if stream is compatible.
+   * @param {Boolean} [options.drm = false]                     - Enable the DRM protected stream playback.
+   * @param {Boolean} [options.disableVideo = false]            - Disable the opportunity to receive video stream.
+   * @param {Boolean} [options.disableAudio = false]            - Disable the opportunity to receive audio stream.
+   * @param {Number} [options.multiplexedAudioTracks]           - Number of audio tracks to recieve VAD multiplexed audio for secondary sources.
+   * @param {String} [options.pinnedSourceId]                   - Id of the main source that will be received by the default MediaStream.
+   * @param {Array<String>} [options.excludedSourceIds]         - Do not receive media from the these source ids.
+   * @param {Array<String>} [options.events]                    - Override which events will be delivered by the server (any of "active" | "inactive" | "vad" | "layers" | "viewercount" | "updated").*
+   * @param {PeerConnectionConfig} [options.peerConfig = null]  - Options to configure the new RTCPeerConnection.
+   * @param {LayerInfo} [options.layer]                         - Select the simulcast encoding layer and svc layers for the main video track, leave empty for automatic layer selection based on bandwidth estimation.
+   * @param {Object} [options.forcePlayoutDelay = false]        - Ask the server to use the playout delay header extension.
+   * @param {Number} [options.forcePlayoutDelay.min]            - Set minimum playout delay value.
+   * @param {Number} [options.forcePlayoutDelay.max]            - Set maximum playout delay value.
+   * @param {Boolean} [options.enableDRM]                       - Enable DRM, default is false.
    * @returns {Promise<void>} Promise object which resolves when the connection was successfully established.
    * @fires PeerConnection#track
    * @fires Signaling#broadcastEvent


### PR DESCRIPTION
Add stats configuration object (`peerConfig`) to `connect` functions in `View` and `Publish` classes.