### PR TITLE
[maxHeight] Expose maxWidth/maxHeight layer constraints in LayerInfo

### DIFF
--- a/.changeset/layer-max-dimensions.md
+++ b/.changeset/layer-max-dimensions.md
@@ -1,0 +1,5 @@
+---
+'@millicast/sdk': minor
+---
+
+Add `maxWidth` and `maxHeight` resolution constraints to `LayerInfo`, so `View.select()`, `View.project()` and `View.connect({ layer })` can limit the resolution of a video track (0 resets the restriction). Supplying only the dimension limits keeps server side ABR active within those limits; supplying `encodingId`, `spatialLayerId` or `temporalLayerId` still fixes the track to that layer. Matches the `maxWidth`/`maxHeight` constraints already available in the native SDKs.

--- a/packages/millicast-sdk/src/Signaling.js
+++ b/packages/millicast-sdk/src/Signaling.js
@@ -16,12 +16,21 @@ export const signalingEvents = {
 }
 
 /**
+ * Layer selection and resolution constraints for a video track.
+ *
+ * Supplying only `maxWidth` and/or `maxHeight` does not pin the track to a layer: server side ABR
+ * stays active and selects the highest layer whose resolution fits within the given limits.
+ * Supplying `encodingId`, `spatialLayerId` or `temporalLayerId` fixes the track to that layer and
+ * bypasses ABR.
+ *
  * @typedef {Object} LayerInfo
  * @property {String} encodingId         - rid value of the simulcast encoding of the track  (default: automatic selection)
  * @property {Number} spatialLayerId     - The spatial layer id to send to the outgoing stream (default: max layer available)
  * @property {Number} temporalLayerId    - The temporaral layer id to send to the outgoing stream (default: max layer available)
  * @property {Number} maxSpatialLayerId  - Max spatial layer id (default: unlimited)
  * @property {Number} maxTemporalLayerId - Max temporal layer id (default: unlimited)
+ * @property {Number} [maxWidth]         - Max width, in pixels, of the layer to receive. ABR stays active and selects the highest layer not wider than this value (default: unlimited, 0 resets the restriction)
+ * @property {Number} [maxHeight]        - Max height, in pixels, of the layer to receive. ABR stays active and selects the highest layer not taller than this value (default: unlimited, 0 resets the restriction)
  */
 
 /**

--- a/packages/millicast-sdk/src/View.js
+++ b/packages/millicast-sdk/src/View.js
@@ -65,12 +65,21 @@ export default class View extends BaseWebRTC {
   }
 
   /**
+     * Layer selection and resolution constraints for a video track.
+     *
+     * Supplying only `maxWidth` and/or `maxHeight` does not pin the track to a layer: server side ABR
+     * stays active and selects the highest layer whose resolution fits within the given limits.
+     * Supplying `encodingId`, `spatialLayerId` or `temporalLayerId` fixes the track to that layer and
+     * bypasses ABR.
+     *
      * @typedef {Object} LayerInfo
      * @property {String} encodingId         - rid value of the simulcast encoding of the track  (default: automatic selection)
      * @property {Number} spatialLayerId     - The spatial layer id to send to the outgoing stream (default: max layer available)
      * @property {Number} temporalLayerId    - The temporaral layer id to send to the outgoing stream (default: max layer available)
      * @property {Number} maxSpatialLayerId  - Max spatial layer id (default: unlimited)
      * @property {Number} maxTemporalLayerId - Max temporal layer id (default: unlimited)
+     * @property {Number} [maxWidth]         - Max width, in pixels, of the layer to receive. ABR stays active and selects the highest layer not wider than this value (default: unlimited, 0 resets the restriction)
+     * @property {Number} [maxHeight]        - Max height, in pixels, of the layer to receive. ABR stays active and selects the highest layer not taller than this value (default: unlimited, 0 resets the restriction)
      */
 
   /**

--- a/packages/millicast-sdk/src/types/index.d.ts
+++ b/packages/millicast-sdk/src/types/index.d.ts
@@ -584,12 +584,21 @@ declare module "@millicast/sdk" {
     }
 
     /**
+     * Layer selection and resolution constraints for a video track.
+     *
+     * Supplying only `maxWidth` and/or `maxHeight` does not pin the track to a layer: server side ABR
+     * stays active and selects the highest layer whose resolution fits within the given limits.
+     * Supplying `encodingId`, `spatialLayerId` or `temporalLayerId` fixes the track to that layer and
+     * bypasses ABR.
+     *
      * @typedef {Object} LayerInfo
      * @property {String} encodingId         - rid value of the simulcast encoding of the track  (default: automatic selection)
      * @property {Number} spatialLayerId     - The spatial layer id to send to the outgoing stream (default: max layer available)
      * @property {Number} temporalLayerId    - The temporaral layer id to send to the outgoing stream (default: max layer available)
      * @property {Number} maxSpatialLayerId  - Max spatial layer id (default: unlimited)
      * @property {Number} maxTemporalLayerId - Max temporal layer id (default: unlimited)
+     * @property {Number} [maxWidth]         - Max width, in pixels, of the layer to receive. ABR stays active and selects the highest layer not wider than this value (default: unlimited, 0 resets the restriction)
+     * @property {Number} [maxHeight]        - Max height, in pixels, of the layer to receive. ABR stays active and selects the highest layer not taller than this value (default: unlimited, 0 resets the restriction)
      */
     /**
      * @typedef {Object} SignalingSubscribeOptions
@@ -663,6 +672,14 @@ declare module "@millicast/sdk" {
          */
         cmd(cmd: string, data?: any): Promise<any>
     }
+    /**
+     * Layer selection and resolution constraints for a video track.
+     *
+     * Supplying only `maxWidth` and/or `maxHeight` does not pin the track to a layer: server side ABR
+     * stays active and selects the highest layer whose resolution fits within the given limits.
+     * Supplying `encodingId`, `spatialLayerId` or `temporalLayerId` fixes the track to that layer and
+     * bypasses ABR.
+     */
     export type LayerInfo = {
         /**
          * - rid value of the simulcast encoding of the track  (default: automatic selection)
@@ -684,6 +701,14 @@ declare module "@millicast/sdk" {
          * - Max temporal layer id (default: unlimited)
          */
         maxTemporalLayerId: number
+        /**
+         * - Max width, in pixels, of the layer to receive. ABR stays active and selects the highest layer not wider than this value (default: unlimited, 0 resets the restriction)
+         */
+        maxWidth?: number
+        /**
+         * - Max height, in pixels, of the layer to receive. ABR stays active and selects the highest layer not taller than this value (default: unlimited, 0 resets the restriction)
+         */
+        maxHeight?: number
     }
     export type SignalingSubscribeOptions = {
         /**
@@ -1203,6 +1228,14 @@ declare module "@millicast/sdk" {
              * - Max temporal layer id (default: unlimited)
              */
             maxTemporalLayerId: number
+            /**
+             * - Max width, in pixels, of the layer to receive. ABR stays active and selects the highest layer not wider than this value (default: unlimited, 0 resets the restriction)
+             */
+            maxWidth?: number
+            /**
+             * - Max height, in pixels, of the layer to receive. ABR stays active and selects the highest layer not taller than this value (default: unlimited, 0 resets the restriction)
+             */
+            maxHeight?: number
         }
         /**
          * - Ask the server to use the playout delay header extension.
@@ -1511,12 +1544,21 @@ declare module "@millicast/sdk" {
     export class View extends BaseWebRTC {
         constructor(streamName: string, tokenGenerator: TokenGeneratorCallback, mediaElement?: HTMLVideoElement, autoReconnect?: boolean)
         /**
+         * Layer selection and resolution constraints for a video track.
+         *
+         * Supplying only `maxWidth` and/or `maxHeight` does not pin the track to a layer: server side ABR
+         * stays active and selects the highest layer whose resolution fits within the given limits.
+         * Supplying `encodingId`, `spatialLayerId` or `temporalLayerId` fixes the track to that layer and
+         * bypasses ABR.
+         *
          * @typedef {Object} LayerInfo
          * @property {String} encodingId         - rid value of the simulcast encoding of the track  (default: automatic selection)
          * @property {Number} spatialLayerId     - The spatial layer id to send to the outgoing stream (default: max layer available)
          * @property {Number} temporalLayerId    - The temporaral layer id to send to the outgoing stream (default: max layer available)
          * @property {Number} maxSpatialLayerId  - Max spatial layer id (default: unlimited)
          * @property {Number} maxTemporalLayerId - Max temporal layer id (default: unlimited)
+         * @property {Number} [maxWidth]         - Max width, in pixels, of the layer to receive. ABR stays active and selects the highest layer not wider than this value (default: unlimited, 0 resets the restriction)
+         * @property {Number} [maxHeight]        - Max height, in pixels, of the layer to receive. ABR stays active and selects the highest layer not taller than this value (default: unlimited, 0 resets the restriction)
          */
         /**
          * Connects to an active stream as subscriber.


### PR DESCRIPTION
## Summary

The server already honours `layer.maxWidth` / `layer.maxHeight` on the `select` and `project` signaling commands (it maps them to `setMaximumDimensions()`), and `View.select()` / `View.project()` / `View.connect({ layer })` forward the layer object verbatim — so this works at runtime today, but the public `LayerInfo` type only declared the encoding/spatial/temporal ids, so TS consumers were rejected and no one could discover the feature. This PR is documentation + typings only; no runtime change, and nothing in the SDK strips or validates unknown layer fields (verified in `View.js` and `Signaling.js`, which pass `layer`/`mapping` straight through to `signaling.cmd`).

The semantic point worth capturing for consumers (and the reason this matters for multiview): the two kinds of layer fields behave very differently.

```js
// Small tile: cap the resolution, ABR still picks the best layer that fits.
view.project(sourceId, [{ media: 'video', trackId: 'video', layer: { maxHeight: 180 } }])

// Fixed layer: pins the track to encoding 'h', ABR is bypassed.
view.project(sourceId, [{ media: 'video', trackId: 'video', layer: { encodingId: 'h' } }])

// Reset the restriction.
view.select({ maxWidth: 0, maxHeight: 0 })
```

Naming matches the native SDKs (`LayerDataSelection.withConstraints()` on Android, `initWithMaxSpatialLayerId:maxTemporalLayerId:maxWidth:maxHeight:` on iOS) so the platforms stay consistent.

Generated `dist/millicast.d.ts` picks the fields up from `src/types/index.d.ts` via the normal build; lint, `tsc --noEmit`, unit tests (29 suites / 173 tests) and `npm run build` pass in `packages/millicast-sdk`.

Jira: https://opentelly.atlassian.net/browse/OPTI-4136 (epic: https://opentelly.atlassian.net/browse/OPTI-4113)


Link to Devin session: https://dolby.devinenterprise.com/sessions/6e4f2fcc6cea412da1d3c06714c2a817
Requested by: @bcostdolby
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/millicast/millicast-sdk/pull/525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->