### PR TITLE
fix: pin @dolbyio/webrtc-stats to 1.0.x (1.2.x bundle has no exports)

### DIFF
--- a/.changeset/pin-webrtc-stats.md
+++ b/.changeset/pin-webrtc-stats.md
@@ -1,0 +1,5 @@
+---
+"@millicast/sdk": patch
+---
+
+Pin @dolbyio/webrtc-stats to 1.0.x; the 1.2.x bundle has no exports and breaks the SDK build.

--- a/packages/millicast-sdk/package.json
+++ b/packages/millicast-sdk/package.json
@@ -52,7 +52,7 @@
     "url": "git+https://github.com/millicast/millicast-sdk.git"
   },
   "dependencies": {
-    "@dolbyio/webrtc-stats": "^1.0.4",
+    "@dolbyio/webrtc-stats": "~1.0.4",
     "@types/node": "^24.0.0",
     "Base64": "^1.1.0",
     "buffer": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
   packages/millicast-sdk:
     dependencies:
       '@dolbyio/webrtc-stats':
-        specifier: ^1.0.4
-        version: 1.2.2
+        specifier: ~1.0.4
+        version: 1.0.4
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
@@ -1113,8 +1113,8 @@ packages:
   '@cucumber/messages@24.1.0':
     resolution: {integrity: sha512-hxVHiBurORcobhVk80I9+JkaKaNXkW6YwGOEFIh/2aO+apAN+5XJgUUWjng9NwqaQrW1sCFuawLB1AuzmBaNdQ==}
 
-  '@dolbyio/webrtc-stats@1.2.2':
-    resolution: {integrity: sha512-3MEZkHDntpo9yOxnBVxV3R3geif4Eut4p7naVOJTTWmLZvdpgQp6ayuKqnbBSvAKFwkv2X8XHQoBA5lcbNoBAw==}
+  '@dolbyio/webrtc-stats@1.0.4':
+    resolution: {integrity: sha512-QOo1TVQSI3NVaSWG1p3JopLkTDB9z94t9Bi1JvJwaQbwrEkLwGXccOX9U+FjroUsfSh9QK2tlifKJifedEBa7w==}
 
   '@emnapi/core@1.4.3':
     resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
@@ -6847,7 +6847,7 @@ snapshots:
       reflect-metadata: 0.2.1
       uuid: 11.1.1
 
-  '@dolbyio/webrtc-stats@1.2.2':
+  '@dolbyio/webrtc-stats@1.0.4':
     dependencies:
       js-logger: 1.6.1
 


### PR DESCRIPTION
## Summary

`main` has been red since #528 bumped `@dolbyio/webrtc-stats` 1.0.4 → 1.2.2 (https://github.com/millicast/millicast-sdk/actions/runs/33724384850). Both published 1.2.x builds ship `dist/webrtc-stats.js` as a bare IIFE (`(()=>{...})();`) with no ESM/CJS exports, so the SDK's `import { WebRTCStats } from '@dolbyio/webrtc-stats'` fails at bundle time:

```
[MISSING_EXPORT] "WebRTCStats" is not exported by ".../@dolbyio/webrtc-stats/dist/webrtc-stats.js"
```

`eslint`, `unit-test` and `e2e-test` all run `pnpm run build` first, hence the three failures.

Fix: `"@dolbyio/webrtc-stats": "^1.0.4"` → `"~1.0.4"` so Dependabot stays on the 1.0.x line until upstream publishes a bundle with exports again; lockfile re-resolves to 1.0.4. Patch changeset added.

Verified locally: build, eslint, 173 unit tests pass.

Link to Devin session: https://dolby.devinenterprise.com/sessions/d0f00a26359548439133f4fce09d50ae
Open in Devin Desktop: https://dolby.devinenterprise.com/desktop/session/d0f00a26359548439133f4fce09d50ae?variant=devin
Requested by: @nicholi
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/millicast/millicast-sdk/pull/532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->