### PR TITLE
ci: install GNU tar in alpine release container for upload-pages-artifact

### DIFF
--- a/.github/workflows/pnpm-build-publish.yml
+++ b/.github/workflows/pnpm-build-publish.yml
@@ -62,6 +62,11 @@ jobs:
 
           printf '\nNODE: %s\nPNPM: %s\n\n' "$(node --version)" "$(pnpm --version)"
 
+      # upload-pages-artifact needs GNU tar (--hard-dereference); busybox tar lacks it
+      - name: Install GNU tar
+        if: inputs.dryrun != true
+        run: apk add --no-cache tar
+
       - name: Upload artifact ⬆️
         uses: actions/upload-pages-artifact@v5
         if: inputs.dryrun != true


### PR DESCRIPTION
## Summary

The release workflow (`pnpm-build-publish.yml`) failed at the `Upload artifact` step on the v0.8.0 run:

```
tar: unrecognized option: hard-dereference
##[error]Process completed with exit code 1.
```

`actions/upload-pages-artifact` archives the docs with `tar --dereference --hard-dereference …`, which are GNU tar options. The job runs in `node:24-alpine`, whose `tar` is busybox. Adds a step before the upload:

```yaml
- name: Install GNU tar
  if: inputs.dryrun != true
  run: apk add --no-cache tar
```

Verified in `node:24-alpine`: after `apk add tar`, `tar --version` → GNU tar 1.35 and `tar --dereference --hard-dereference -cvf …` succeeds.

Nothing else in the run was affected — build, docs and the `printf` node/pnpm summary completed; publish never ran because the job aborted at the upload step, so re-running the release for v0.8.0 after merge should publish normally.

Link to Devin session: https://dolby.devinenterprise.com/sessions/d0f00a26359548439133f4fce09d50ae
Open in Devin Desktop: https://dolby.devinenterprise.com/desktop/session/d0f00a26359548439133f4fce09d50ae?variant=devin
Requested by: @nicholi
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/millicast/millicast-sdk/pull/536" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->