### PR TITLE
fix: anchor jsdoc excludePattern to basename so docs build in the release container

### DIFF
--- a/.changeset/jsdoc-exclude-pattern.md
+++ b/.changeset/jsdoc-exclude-pattern.md
@@ -1,0 +1,5 @@
+---
+"@millicast/sdk": patch
+---
+
+Fix jsdoc `excludePattern` so docs build when the checkout path contains `_` (e.g. GitHub Actions containers).

--- a/packages/millicast-sdk/jsdoc.json
+++ b/packages/millicast-sdk/jsdoc.json
@@ -7,7 +7,7 @@
       "src"
     ],
     "includePattern": ".+\\.js(doc|x)?$",
-    "excludePattern": "(^|\\/|\\\\)_"
+    "excludePattern": "(^|[\\/\\\\])_[^\\/\\\\]*$"
   },
   "plugins": [
     "plugins/markdown",


### PR DESCRIPTION
## Summary

The v0.8.0 release run failed at `Upload artifact` with `packages/millicast-sdk/docs: No such file or directory` because `build-docs` produced nothing — jsdoc printed `There are no input files to process.`

Cause: jsdoc tests `source.excludePattern` against the **absolute** path of each file. The pattern `(^|\/|\\)_` (intended to skip files whose name starts with `_`) matches any path segment beginning with `_`. Inside the `node:24-alpine` job container the workspace is mounted at `/__w/millicast-sdk/millicast-sdk/...`, so every source file was excluded. The `build-docs` check on plain `ubuntu-latest` (`/home/runner/work/...`) never hit this, which is why CI was green while the release failed.

```diff
-"excludePattern": "(^|\\/|\\\\)_"
+"excludePattern": "(^|[\\/\\\\])_[^\\/\\\\]*$"
```

The new pattern only matches when the *last* segment starts with `_`. Verified in `node:24-alpine` with the repo mounted at `/__w/millicast-sdk/millicast-sdk`: 20 source files parsed, `docs/` generated, and a test `src/_private.js` is still excluded.

Link to Devin session: https://dolby.devinenterprise.com/sessions/d0f00a26359548439133f4fce09d50ae
Open in Devin Desktop: https://dolby.devinenterprise.com/desktop/session/d0f00a26359548439133f4fce09d50ae?variant=devin
Requested by: @nicholi
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/millicast/millicast-sdk/pull/537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->