### PR TITLE
ci: move GitHub Pages deploy into its own job gated by the github-pages environment

### DIFF
--- a/.github/workflows/pnpm-build-publish.yml
+++ b/.github/workflows/pnpm-build-publish.yml
@@ -35,10 +35,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      pages: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     defaults:
       run:
         shell: 'ash -euo pipefail {0}'
@@ -47,39 +43,25 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Setup GitHub Pages 🛠
-        uses: actions/configure-pages@v6
-        if: inputs.dryrun != true
-
       - name: "pnpm build"
         env:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
         run: |
           cp README.md ./packages/millicast-sdk/
-  
+
           corepack enable
           pnpm ci
-  
+
           pnpm --filter @millicast/sdk run build
           pnpm --filter @millicast/sdk run build-docs
 
           printf '\nNODE: %s\nPNPM: %s\n\n' "$(node --version)" "$(pnpm --version)"
 
-      # upload-pages-artifact needs GNU tar (--hard-dereference); busybox tar lacks it
-      - name: Install GNU tar
-        if: inputs.dryrun != true
-        run: apk add --no-cache tar
-
-      - name: Upload artifact ⬆️
-        uses: actions/upload-pages-artifact@v5
-        if: inputs.dryrun != true
+      - uses: actions/upload-artifact@v7
         with:
-          path: './packages/millicast-sdk/docs'
-
-      - name: Deploy to GitHub Pages 🚀
-        id: deployment
-        uses: actions/deploy-pages@v5
-        if: inputs.dryrun != true
+          name: sdk-docs
+          path: packages/millicast-sdk/docs
+          retention-days: 1
 
       - name: "pnpm publish"
         env:
@@ -95,3 +77,37 @@ jobs:
           fi
 
           pnpm --filter @millicast/sdk publish --provenance --no-git-checks "$@"
+
+  build-docs:
+    name: "build-docs ${{ inputs.ref }}"
+    runs-on: ubuntu-latest
+    container: debian:stable-slim
+    if: inputs.dryrun != true
+    needs: [build-publish]
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: sdk-docs
+          path: packages/millicast-sdk/docs
+
+      - name: Setup GitHub Pages 🛠
+        uses: actions/configure-pages@v6
+
+      - name: Upload artifact ⬆️
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: packages/millicast-sdk/docs
+
+      - id: deployment
+        name: Deploy to GitHub Pages 🚀
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pnpm-build-publish.yml
+++ b/.github/workflows/pnpm-build-publish.yml
@@ -62,6 +62,7 @@ jobs:
           name: sdk-docs
           path: packages/millicast-sdk/docs
           retention-days: 1
+          overwrite: true
 
       - name: "pnpm publish"
         env:

--- a/.github/workflows/pnpm-build-publish.yml
+++ b/.github/workflows/pnpm-build-publish.yml
@@ -81,7 +81,6 @@ jobs:
   deploy-docs:
     name: "build-docs ${{ inputs.ref }}"
     runs-on: ubuntu-latest
-    container: debian:stable-slim
     if: inputs.dryrun != true
     needs: [build-publish]
     permissions:

--- a/.github/workflows/pnpm-build-publish.yml
+++ b/.github/workflows/pnpm-build-publish.yml
@@ -36,6 +36,9 @@ jobs:
       contents: read
       id-token: write
       pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     defaults:
       run:
         shell: 'ash -euo pipefail {0}'

--- a/.github/workflows/pnpm-build-publish.yml
+++ b/.github/workflows/pnpm-build-publish.yml
@@ -78,7 +78,7 @@ jobs:
 
           pnpm --filter @millicast/sdk publish --provenance --no-git-checks "$@"
 
-  build-docs:
+  deploy-docs:
     name: "build-docs ${{ inputs.ref }}"
     runs-on: ubuntu-latest
     container: debian:stable-slim


### PR DESCRIPTION
## Summary

The v0.8.0 release run built, generated docs and uploaded the Pages artifact, but `actions/deploy-pages@v5` failed with:

```
HttpError: Missing environment. Ensure your workflow's deployment job has an environment.
```

The Pages deployment API requires the calling job to run inside an environment. Rather than put `environment: github-pages` on the job that also runs `pnpm publish --provenance` (which would add an `environment` claim to the OIDC token used for npm Trusted Publishing), the Pages work is split into its own job:

```yaml
build-publish:            # node:24-alpine
  - pnpm build + build-docs
  - actions/upload-artifact  name: sdk-docs  (retention-days: 1, overwrite: true)
  - pnpm publish --provenance

deploy-docs:              # ubuntu-latest, needs: build-publish, if: !dryrun
  environment: github-pages
  - actions/download-artifact  sdk-docs
  - configure-pages / upload-pages-artifact / deploy-pages
```

Side effects of the split:

- `build-publish` drops `pages: write`, `configure-pages`, `upload-pages-artifact`, `deploy-pages` and the `apk add tar` workaround (upload-pages-artifact's GNU `tar --hard-dereference` now runs on the plain ubuntu runner).
- The job id is `deploy-docs` (not `build-docs`) to avoid colliding with the required `build-docs` status check from `check-tests.yml`.
- A Pages failure is recovered with "Re-run failed jobs", which re-runs only `deploy-docs` against the same run's `sdk-docs` artifact; the already-published npm version is not touched.

Link to Devin session: https://dolby.devinenterprise.com/sessions/d0f00a26359548439133f4fce09d50ae
Open in Devin Desktop: https://dolby.devinenterprise.com/desktop/session/d0f00a26359548439133f4fce09d50ae?variant=devin
Requested by: @nicholi
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/millicast/millicast-sdk/pull/538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->