### PR TITLE
fix(docs): set clean-jsdoc-theme basePath so the GitHub Pages site loads

### DIFF
--- a/.changeset/jsdoc-base-path.md
+++ b/.changeset/jsdoc-base-path.md
@@ -1,0 +1,5 @@
+---
+"@millicast/sdk": patch
+---
+
+Fix the published docs site: set the clean-jsdoc-theme v5 `basePath` to `/millicast-sdk/` and move `siteName`/`menu` to the v5 option names so assets, page links and the header render correctly on GitHub Pages.

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 coverage
 dist
 docs
+docs-preview
 docs-translations
 .env
 puppeteerrc.cjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ Or if you want to navigate to the docs on your local machine, run:
 pnpm run start-docs
 ```
 
-In the logs you find the link where you can access to docs. By default, the logs run on http://localhost:5000.
+The docs are served under the same `/millicast-sdk/` prefix as the published site, e.g. http://localhost:3000/millicast-sdk/.
 
 ### SDK Components
 

--- a/packages/millicast-sdk/jsdoc.json
+++ b/packages/millicast-sdk/jsdoc.json
@@ -15,7 +15,7 @@
     "node_modules/jsdoc-i18n-plugin/index.js"
   ],
   "markdown": {
-    "idInHeadings": true 
+    "idInHeadings": true
   },
   "i18n": {
     "locale": "en",
@@ -29,22 +29,20 @@
     "destination": "docs/",
     "recurse": true,
     "verbose": true,
-    "theme_opts": {
-      "title": "Millicast SDK",
-      "theme": "light",
-      "menu": [
-        {
-          "title": "Github",
-          "link": "https://github.com/millicast/millicast-sdk",
-          "target": "_blank"
-        },
-        {
-          "title": "NPM Package",
-          "link": "https://www.npmjs.com/package/@millicast/sdk",
-          "target": "_blank"
-        }
-      ]
-    }
+    "siteName": "Millicast SDK",
+    "menu": [
+      {
+        "title": "Github",
+        "link": "https://github.com/millicast/millicast-sdk",
+        "target": "_blank"
+      },
+      {
+        "title": "NPM Package",
+        "link": "https://www.npmjs.com/package/@millicast/sdk",
+        "target": "_blank"
+      }
+    ],
+    "basePath": "/millicast-sdk/"
   },
   "templates": {
     "cleverLinks": false,

--- a/packages/millicast-sdk/package.json
+++ b/packages/millicast-sdk/package.json
@@ -21,7 +21,7 @@
     "build": "tsc --build && vite build --config vite.config.debug.mjs && vite build && rollup -c",
     "build:watch": "vite build --watch",
     "build-docs": "jsdoc -c jsdoc.json -R ../../README.md",
-    "start-docs": "pnpm run build-docs && rm -rf docs-preview && mkdir docs-preview && ln -s ../docs docs-preview/millicast-sdk && serve --symlinks docs-preview",
+    "start-docs": "jsdoc -c jsdoc.json -R ../../README.md -d docs-preview/millicast-sdk && serve docs-preview",
     "test-unit": "pnpm run build && jest --testMatch \"**/unit/*.steps.js\"",
     "test-unit-coverage": "pnpm run build && jest --testMatch \"**/unit/*.steps.js\" --coverage",
     "test-e2e": "pnpm run build && cross-env NODE_OPTIONS=--experimental-vm-modules jest --testMatch \"**/e2e/*.steps.js\" --verbose",

--- a/packages/millicast-sdk/package.json
+++ b/packages/millicast-sdk/package.json
@@ -21,7 +21,7 @@
     "build": "tsc --build && vite build --config vite.config.debug.mjs && vite build && rollup -c",
     "build:watch": "vite build --watch",
     "build-docs": "jsdoc -c jsdoc.json -R ../../README.md",
-    "start-docs": "pnpm run build-docs && serve docs",
+    "start-docs": "pnpm run build-docs && rm -rf docs-preview && mkdir docs-preview && ln -s ../docs docs-preview/millicast-sdk && serve --symlinks docs-preview",
     "test-unit": "pnpm run build && jest --testMatch \"**/unit/*.steps.js\"",
     "test-unit-coverage": "pnpm run build && jest --testMatch \"**/unit/*.steps.js\" --coverage",
     "test-e2e": "pnpm run build && cross-env NODE_OPTIONS=--experimental-vm-modules jest --testMatch \"**/e2e/*.steps.js\" --verbose",


### PR DESCRIPTION
## Summary

https://millicast.github.io/millicast-sdk/ is unstyled and every link/`import()` 404s. `clean-jsdoc-theme` 4→5 (#527) changed the output model: pages are now `<slug>/index.html` and all asset/page URLs are emitted root-absolute from `opts.basePath` (default `/`), e.g. `/_assets/styles.css`, `/_islands/sidebar.js`, `/basewebrtc`. GitHub Pages serves the project under `/millicast-sdk/`, so the browser requests `https://millicast.github.io/_assets/...` instead.

v5 also stopped reading `opts.theme_opts` — its options now live directly under `opts` — so the `title`/`menu` block was silently ignored. `theme` (light/dark) has no v5 equivalent (there's a runtime toggle).

```diff
 "opts": {
-  "theme_opts": { "title": "Millicast SDK", "theme": "light", "menu": [...] }
+  "siteName": "Millicast SDK",
+  "menu": [...],
+  "basePath": "/millicast-sdk/"
 }
```

Verified locally: `build-docs` output now emits `/millicast-sdk/_assets/...`, `/millicast-sdk/_islands/...`, `/millicast-sdk/<page>` everywhere (no remaining bare `/_assets`/`/_islands` refs across the generated html/js), the header shows the site name and both menu links, and all referenced URLs resolve when the output is served under a `/millicast-sdk/` prefix.

Takes effect on the next release run (docs are built and deployed by the release workflow).

Link to Devin session: https://dolby.devinenterprise.com/sessions/d0f00a26359548439133f4fce09d50ae
Open in Devin Desktop: https://dolby.devinenterprise.com/desktop/session/d0f00a26359548439133f4fce09d50ae?variant=devin
Requested by: @nicholi
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/millicast/millicast-sdk/pull/540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->