### PR TITLE
deps: bump @dolbyio/webrtc-stats to ^1.3.0

### DIFF
--- a/.changeset/bump-webrtc-stats.md
+++ b/.changeset/bump-webrtc-stats.md
@@ -1,0 +1,5 @@
+---
+"@millicast/sdk": patch
+---
+
+Bump `@dolbyio/webrtc-stats` to `^1.3.0` and drop the `~1.0.4` pin.

--- a/packages/millicast-sdk/package.json
+++ b/packages/millicast-sdk/package.json
@@ -52,7 +52,7 @@
     "url": "git+https://github.com/millicast/millicast-sdk.git"
   },
   "dependencies": {
-    "@dolbyio/webrtc-stats": "~1.0.4",
+    "@dolbyio/webrtc-stats": "^1.3.0",
     "@types/node": "^24.0.0",
     "Base64": "^1.1.0",
     "buffer": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
   packages/millicast-sdk:
     dependencies:
       '@dolbyio/webrtc-stats':
-        specifier: ~1.0.4
-        version: 1.0.4
+        specifier: ^1.3.0
+        version: 1.3.0
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
@@ -972,8 +972,8 @@ packages:
   '@cucumber/messages@24.1.0':
     resolution: {integrity: sha512-hxVHiBurORcobhVk80I9+JkaKaNXkW6YwGOEFIh/2aO+apAN+5XJgUUWjng9NwqaQrW1sCFuawLB1AuzmBaNdQ==}
 
-  '@dolbyio/webrtc-stats@1.0.4':
-    resolution: {integrity: sha512-QOo1TVQSI3NVaSWG1p3JopLkTDB9z94t9Bi1JvJwaQbwrEkLwGXccOX9U+FjroUsfSh9QK2tlifKJifedEBa7w==}
+  '@dolbyio/webrtc-stats@1.3.0':
+    resolution: {integrity: sha512-MfZ/Gr+7F0FfnWalb5QwD5cyR6QpfnUOgjDh7rvT3lrKTyKILMsazbrCshxQBXMiysWHlmIm0pkJRDIr5eL9pA==}
 
   '@emnapi/core@1.4.3':
     resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
@@ -5813,7 +5813,7 @@ snapshots:
       reflect-metadata: 0.2.1
       uuid: 11.1.1
 
-  '@dolbyio/webrtc-stats@1.0.4':
+  '@dolbyio/webrtc-stats@1.3.0':
     dependencies:
       js-logger: 1.6.1
 


### PR DESCRIPTION
## Summary
Replaces dependabot PR #539 (which targeted 1.2.2). Updates `@dolbyio/webrtc-stats` in `packages/millicast-sdk` from the tilde pin `~1.0.4` to the normal caret range `^1.3.0`, now that 1.3.0 is published and the earlier test issues are resolved. Lockfile updated with `pnpm install`; a patch changeset is included.

`pnpm run test-unit` (build + 29 unit suites, 173 tests) passes locally.


Link to Devin session: https://dolby.devinenterprise.com/sessions/39bf84aa047446468fd18cf92f598c28
Open in Devin Desktop: https://dolby.devinenterprise.com/desktop/session/39bf84aa047446468fd18cf92f598c28?variant=devin
Requested by: @nicholi
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/millicast/millicast-sdk/pull/543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->